### PR TITLE
fix: get selected text in macOS

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1982,6 +1982,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "macos-accessibility-client"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edf7710fbff50c24124331760978fb9086d6de6288dcdb38b25a97f8b1bdebbb"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+]
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2664,6 +2674,7 @@ dependencies = [
  "dirs 5.0.1",
  "dunce",
  "enigo",
+ "macos-accessibility-client",
  "mouse_position",
  "once_cell",
  "reqwest",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,12 +31,13 @@ windows = {version="0.44.0",features= ["Win32_UI_WindowsAndMessaging", "Win32_Fo
 window-shadows = "0.2"
 arboard = "3.2.0"
 
-[target.'cfg(target_os = "macos")'.dependencies ]
+[target.'cfg(target_os = "macos")'.dependencies]
 window-shadows = "0.2"
 core-graphics = "0.22.3"
 arboard = "3.2.0"
+macos-accessibility-client = "0.0.1"
 
-[target.'cfg(target_os = "linux")'.dependencies ]
+[target.'cfg(target_os = "linux")'.dependencies]
 mouse_position = "0.1.3"
 x11-clipboard = "0.7.1"
 wl-clipboard-rs = "0.7.0"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -24,12 +24,32 @@ use trayicon::*;
 use utils::*;
 use window::*;
 
+#[cfg(target_os = "macos")]
+fn query_accessibility_permissions() -> bool {
+    let trusted = macos_accessibility_client::accessibility::application_is_trusted_with_prompt();
+    if trusted {
+        print!("Application is totally trusted!");
+    } else {
+        print!("Application isn't trusted :(");
+    }
+    trusted
+}
+
+#[cfg(not(target_os = "macos"))]
+fn query_accessibility_permissions() -> bool {
+    return true;
+}
+
 // 全局AppHandle
 pub static APP: OnceCell<AppHandle> = OnceCell::new();
 // 存待翻译文本
 pub struct StringWrapper(pub Mutex<String>);
 
 fn main() {
+    if !query_accessibility_permissions() {
+        return
+    }
+
     tauri::Builder::default()
         // 单例运行
         .plugin(tauri_plugin_single_instance::init(|app, argv, cwd| {

--- a/src-tauri/src/window.rs
+++ b/src-tauri/src/window.rs
@@ -213,10 +213,13 @@ fn get_mouse_location() -> Result<(f64, f64), String> {
 // 划词翻译
 pub fn translate_window() {
     // 获取选择文本
-    let mut text = String::new();
-    if let Ok(v) = get_selection_text() {
-        text = v;
-    }
+    let text = match get_selection_text() {
+        Ok(v) => v,
+        Err(err) => {
+            println!("get selection text error: {:?}", err);
+            String::new()
+        }
+    };
     let handle = APP.get().unwrap();
     // 写入状态备用
     let state: tauri::State<StringWrapper> = handle.state();


### PR DESCRIPTION
1. Grant accessibility permission to obtain the keystroke permissions
2. Use the clipboard to retrieve the selected text for better compatibility
3. Use `osascript -e` to execute the command string instead of a file