### PR TITLE
重构快捷键输入，解决设置快捷键闪退

### DIFF
--- a/src/windows/Config/pages/ShortCutConfig/index.jsx
+++ b/src/windows/Config/pages/ShortCutConfig/index.jsx
@@ -7,14 +7,45 @@ import ConfigItem from '../../components/ConfigItem';
 import ConfigList from '../../components/ConfigList';
 import { set } from '../../../../global/config';
 
+const keyMap = {
+    Backquote: '`',
+    Backslash: '\\',
+    BracketLeft: '[',
+    BracketRight: ']',
+    Comma: ',',
+    Equal: '=',
+    Minus: '-',
+    Plus: 'PLUS',
+    Period: '.',
+    Quote: "'",
+    Semicolon: ';',
+    Slash: '/',
+    Backspace: 'Backspace',
+    CapsLock: 'Capslock',
+    ContextMenu: 'Contextmenu',
+    Space: 'Space',
+    Tab: 'Tab',
+    Convert: 'Convert',
+    Delete: 'Delete',
+    End: 'End',
+    Help: 'Help',
+    Home: 'Home',
+    PageDown: 'Pagedown',
+    PageUp: 'Pageup',
+    Escape: 'Esc',
+    PrintScreen: 'Printscreen',
+    ScrollLock: 'Scrolllock',
+    Pause: 'Pause',
+    Insert: 'Insert',
+    Suspend: 'Suspend',
+};
+
 export default function ShortCutConfig() {
     const [shortcutTranslate, setShortcutTranslate] = useAtom(shortcutTranslateAtom);
     const [shortcutPersistent, setShortcutPersistent] = useAtom(shortcutPersistentAtom);
     const [shortcutOcr, setShortcutOcr] = useAtom(shortcutOcrAtom);
     const [isMacos, setIsMacos] = useState(false);
     const [isWayland, setIsWayland] = useState(false);
-
-    const supportKey = ['Control', 'Shift', 'Alt', 'Meta'];
 
     useEffect(() => {
         invoke('is_macos').then((v) => {
@@ -25,41 +56,42 @@ export default function ShortCutConfig() {
         });
     });
 
-    function keyDown(e, value, setKey) {
-        if (e.key.length == 1) {
-            if (value) {
-                let values = value.toUpperCase().split('+');
-                let key = e.key.toUpperCase();
-                if (!value.startsWith('F') && !values.includes(key)) {
-                    setKey(value + '+' + key);
-                }
-            }
+    function keyDown(e, setKey) {
+        if (e.keyCode == 8) {
+            setKey('');
         } else {
-            if (supportKey.includes(e.key)) {
-                if (e.key == 'Meta' && !isMacos) {
-                    if (isMacos) {
-                        e.key = 'Command';
-                    } else {
-                        e.key = 'Super';
-                    }
-                }
-                if (value) {
-                    let values = value.split('+');
-                    if (!value.startsWith('F') && !values.includes(e.key)) {
-                        setKey(value + '+' + e.key);
-                    } else {
-                        setKey(e.key);
-                    }
-                } else {
-                    setKey(e.key);
-                }
-            } else if (e.key.startsWith('F') && !isMacos) {
-                setKey(e.key);
-            } else {
-                if (e.keyCode == 8) {
-                    setKey('');
-                }
+            let newValue = '';
+            if (e.ctrlKey) {
+                newValue = 'Ctrl';
             }
+            if (e.shiftKey) {
+                newValue = `${newValue}${newValue.length > 0 ? '+' : ''}Shift`;
+            }
+            if (e.metaKey) {
+                newValue = `${newValue}${newValue.length > 0 ? '+' : ''}${isMacos ? 'Command' : 'Super'}`;
+            }
+            if (e.altKey) {
+                newValue = `${newValue}${newValue.length > 0 ? '+' : ''}Alt`;
+            }
+            let code = e.code;
+            if (code.startsWith('Key')) {
+                code = code.substring(3);
+            } else if (code.startsWith('Digit')) {
+                code = code.substring(5);
+            } else if (code.startsWith('Numpad')) {
+                code = 'Num' + code.substring(6);
+            } else if (code.startsWith('Arrow')) {
+                code = code.substring(5);
+            } else if (code.startsWith('Intl')) {
+                code = code.substring(4);
+            } else if (/F\d+/.test(code)) {
+                // F1-F12 不处理
+            } else if (keyMap[code] !== undefined) {
+                code = keyMap[code];
+            } else {
+                code = '';
+            }
+            setKey(`${newValue}${newValue.length > 0 && code.length > 0 ? '+' : ''}${code}`);
         }
     }
 
@@ -76,7 +108,7 @@ export default function ShortCutConfig() {
                     value={shortcutTranslate}
                     placeholder='可直接按下组合键设置，也可逐个按下按键设置'
                     onKeyDown={(e) => {
-                        keyDown(e, shortcutTranslate, setShortcutTranslate);
+                        keyDown(e, setShortcutTranslate);
                     }}
                     onFocus={() => {
                         setShortcutTranslate('');
@@ -109,7 +141,7 @@ export default function ShortCutConfig() {
                     placeholder='可直接按下组合键设置，也可逐个按下按键设置'
                     value={shortcutPersistent}
                     onKeyDown={(e) => {
-                        keyDown(e, shortcutPersistent, setShortcutPersistent);
+                        keyDown(e, setShortcutPersistent);
                     }}
                     onFocus={() => {
                         setShortcutPersistent('');


### PR DESCRIPTION
修复 #111 

因为原来的快捷键设置是一个键一个键的读取按键信息，最终可能会出现 `Shift+?` 这类非法的快捷键，导致 rust 端注册快捷键时崩溃。

我参考 rust 的映射表添加重写了解析函数，并且读取原生的按键事件中的快捷键组合结果。