### PR TITLE
refactor: improve a11y of collection pages

### DIFF
--- a/src/components/WindowControl/index.jsx
+++ b/src/components/WindowControl/index.jsx
@@ -26,7 +26,7 @@ export default function WindowControl() {
                 isIconOnly
                 variant='light'
                 className='w-[35px] h-[35px] rounded-none'
-                onClick={() => appWindow.minimize()}
+                onPress={() => appWindow.minimize()}
             >
                 <VscChromeMinimize className='text-[16px]' />
             </Button>
@@ -34,7 +34,7 @@ export default function WindowControl() {
                 isIconOnly
                 variant='light'
                 className='w-[35px] h-[35px] rounded-none'
-                onClick={() => {
+                onPress={() => {
                     if (isMax) {
                         appWindow.unmaximize();
                     } else {
@@ -48,7 +48,7 @@ export default function WindowControl() {
                 isIconOnly
                 variant='light'
                 className={`w-[35px] h-[35px] rounded-none close-button ${osType === 'Linux' && 'rounded-tr-[10px]'}`}
-                onClick={() => appWindow.close()}
+                onPress={() => appWindow.close()}
             >
                 <VscChromeClose className='text-[16px]' />
             </Button>

--- a/src/services/collection/anki/Config.jsx
+++ b/src/services/collection/anki/Config.jsx
@@ -18,45 +18,52 @@ export function Config(props) {
         ankiConfig !== null && (
             <>
                 <Toaster />
-                <div className={'config-item'}>
-                    <h3 className='my-auto'>{t('services.collection.anki.port')}</h3>
-                    <Input
-                        value={ankiConfig['port']}
-                        type='number'
-                        variant='bordered'
-                        className='max-w-[50%]'
-                        onValueChange={(value) => {
-                            setAnkiConfig({
-                                ...ankiConfig,
-                                port: value,
-                            });
-                        }}
-                    />
-                </div>
-                <div>
+                <form
+                    onSubmit={(e) => {
+                        e.preventDefault();
+                        setIsLoading(true);
+                        collection('test', '测试', { config: ankiConfig }).then(
+                            () => {
+                                setIsLoading(false);
+                                setAnkiConfig(ankiConfig, true);
+                                updateServiceList('anki');
+                                onClose();
+                            },
+                            (e) => {
+                                setIsLoading(false);
+                                toast.error(t('config.service.test_failed') + e.toString(), { style: toastStyle });
+                            }
+                        );
+                    }}
+                >
+                    <div className={'config-item'}>
+                        <Input
+                            label={t('services.collection.anki.port')}
+                            labelPlacement='outside-left'
+                            value={ankiConfig['port']}
+                            type='number'
+                            variant='bordered'
+                            classNames={{
+                                base: 'justify-between',
+                                label: 'text-[length:--nextui-font-size-medium]',
+                                mainWrapper: 'max-w-[50%]',
+                            }}
+                            onValueChange={(value) => {
+                                setAnkiConfig({
+                                    ...ankiConfig,
+                                    port: value,
+                                });
+                            }}
+                        />
+                    </div>
                     <Button
                         isLoading={isLoading}
                         fullWidth
                         color='primary'
-                        onPress={() => {
-                            setIsLoading(true);
-                            collection('test', '测试', { config: ankiConfig }).then(
-                                () => {
-                                    setIsLoading(false);
-                                    setAnkiConfig(ankiConfig, true);
-                                    updateServiceList('anki');
-                                    onClose();
-                                },
-                                (e) => {
-                                    setIsLoading(false);
-                                    toast.error(t('config.service.test_failed') + e.toString(), { style: toastStyle });
-                                }
-                            );
-                        }}
                     >
                         {t('common.save')}
                     </Button>
-                </div>
+                </form>
             </>
         )
     );

--- a/src/services/collection/anki/Config.jsx
+++ b/src/services/collection/anki/Config.jsx
@@ -57,6 +57,7 @@ export function Config(props) {
                         />
                     </div>
                     <Button
+                        type='submit'
                         isLoading={isLoading}
                         fullWidth
                         color='primary'

--- a/src/services/collection/eudic/Config.jsx
+++ b/src/services/collection/eudic/Config.jsx
@@ -18,58 +18,73 @@ export function Config(props) {
         config !== null && (
             <>
                 <Toaster />
-                <div className={'config-item'}>
-                    <h3 className='my-auto'>{t('services.collection.eudic.name')}</h3>
-                    <Input
-                        value={config['name']}
-                        variant='bordered'
-                        className='max-w-[50%]'
-                        onValueChange={(value) => {
-                            setConfig({
-                                ...config,
-                                name: value,
-                            });
-                        }}
-                    />
-                </div>
-                <div className={'config-item'}>
-                    <h3 className='my-auto'>{t('services.collection.eudic.token')}</h3>
-                    <Input
-                        value={config['token']}
-                        variant='bordered'
-                        className='max-w-[50%]'
-                        onValueChange={(value) => {
-                            setConfig({
-                                ...config,
-                                token: value,
-                            });
-                        }}
-                    />
-                </div>
-                <div>
-                    <Button
-                        isLoading={isLoading}
-                        fullWidth
-                        color='primary'
-                        onPress={() => {
-                            setIsLoading(true);
-                            collection('test', '测试', { config }).then(
-                                () => {
-                                    setIsLoading(false);
-                                    setConfig(config, true);
-                                    updateServiceList('eudic');
-                                    onClose();
-                                },
-                                (e) => {
-                                    setIsLoading(false);
-                                    toast.error(t('config.service.test_failed') + e.toString(), { style: toastStyle });
-                                }
-                            );
-                        }}
-                    >
-                        {t('common.save')}
-                    </Button>
-                </div>
+                <form
+                    onSubmit={(e) => {
+                        e.preventDefault();
+                        setIsLoading(true);
+                        collection('test', '测试', { config }).then(
+                            () => {
+                                setIsLoading(false);
+                                setConfig(config, true);
+                                updateServiceList('eudic');
+                                onClose();
+                            },
+                            (e) => {
+                                setIsLoading(false);
+                                toast.error(t('config.service.test_failed') + e.toString(), { style: toastStyle });
+                            }
+                        );
+                    }}
+                >
+                    <div className={'config-item'}>
+                        <Input
+                            label={t('services.collection.eudic.name')}
+                            labelPlacement='outside-left'
+                            value={config['name']}
+                            variant='bordered'
+                            classNames={{
+                                base: 'justify-between',
+                                label: 'text-[length:--nextui-font-size-medium]',
+                                mainWrapper: 'max-w-[50%]'
+                            }}
+                            onValueChange={(value) => {
+                                setConfig({
+                                    ...config,
+                                    name: value,
+                                });
+                            }}
+                        />
+                    </div>
+                    <div className={'config-item'}>
+                        <Input
+                            label={t('services.collection.eudic.token')}
+                            labelPlacement='outside-left'
+                            value={config['token']}
+                            variant='bordered'
+                            classNames={{
+                                base: 'justify-between',
+                                label: 'text-[length:--nextui-font-size-medium]',
+                                mainWrapper: 'max-w-[50%]'
+                            }}
+                            onValueChange={(value) => {
+                                setConfig({
+                                    ...config,
+                                    token: value,
+                                });
+                            }}
+                        />
+                    </div>
+                    <div>
+                        <Button
+                            type='submit'
+                            isLoading={isLoading}
+                            fullWidth
+                            color='primary'
+                        >
+                            {t('common.save')}
+                        </Button>
+                    </div>
+                </form>
             </>
         )
     );

--- a/src/window/Config/components/SideBar/index.jsx
+++ b/src/window/Config/components/SideBar/index.jsx
@@ -27,7 +27,7 @@ export default function SideBar() {
                 size='lg'
                 variant={setStyle('/general')}
                 className='mb-[5px]'
-                onClick={() => {
+                onPress={() => {
                     navigate('/general');
                 }}
                 startContent={<AiFillAppstore className='text-[24px]' />}
@@ -39,7 +39,7 @@ export default function SideBar() {
                 size='lg'
                 variant={setStyle('/translate')}
                 className='mb-[5px]'
-                onClick={() => {
+                onPress={() => {
                     navigate('/translate');
                 }}
                 startContent={<PiTranslateFill className='text-[24px]' />}
@@ -51,7 +51,7 @@ export default function SideBar() {
                 size='lg'
                 variant={setStyle('/recognize')}
                 className='mb-[5px]'
-                onClick={() => {
+                onPress={() => {
                     navigate('/recognize');
                 }}
                 startContent={<PiTextboxFill className='text-[24px]' />}
@@ -63,7 +63,7 @@ export default function SideBar() {
                 size='lg'
                 variant={setStyle('/hotkey')}
                 className='mb-[5px]'
-                onClick={() => {
+                onPress={() => {
                     navigate('/hotkey');
                 }}
                 startContent={<MdKeyboardAlt className='text-[24px]' />}
@@ -75,7 +75,7 @@ export default function SideBar() {
                 size='lg'
                 variant={setStyle('/service')}
                 className='mb-[5px]'
-                onClick={() => {
+                onPress={() => {
                     navigate('/service');
                 }}
                 startContent={<MdExtension className='text-[24px]' />}
@@ -87,7 +87,7 @@ export default function SideBar() {
                 size='lg'
                 variant={setStyle('/history')}
                 className='mb-[5px]'
-                onClick={() => {
+                onPress={() => {
                     navigate('/history');
                 }}
                 startContent={<FaHistory className='text-[24px]' />}
@@ -99,7 +99,7 @@ export default function SideBar() {
                 size='lg'
                 variant={setStyle('/backup')}
                 className='mb-[5px]'
-                onClick={() => {
+                onPress={() => {
                     navigate('/backup');
                 }}
                 startContent={<AiFillCloud className='text-[24px]' />}
@@ -111,7 +111,7 @@ export default function SideBar() {
                 size='lg'
                 variant={setStyle('/about')}
                 className='mb-[5px]'
-                onClick={() => {
+                onPress={() => {
                     navigate('/about');
                 }}
                 startContent={<BsInfoSquareFill className='text-[24px]' />}

--- a/src/window/Config/pages/About/index.jsx
+++ b/src/window/Config/pages/About/index.jsx
@@ -29,7 +29,7 @@ export default function About() {
                         variant='light'
                         className='my-[5px]'
                         size='sm'
-                        onClick={() => {
+                        onPress={() => {
                             open('https://pot-app.com');
                         }}
                     >
@@ -39,7 +39,7 @@ export default function About() {
                         variant='light'
                         className='my-[5px]'
                         size='sm'
-                        onClick={() => {
+                        onPress={() => {
                             open('https://github.com/pot-app/pot-desktop');
                         }}
                     >
@@ -64,7 +64,7 @@ export default function About() {
                                     variant='light'
                                     className='my-[5px]'
                                     size='sm'
-                                    onClick={() => {
+                                    onPress={() => {
                                         open('https://github.com/pot-app/pot-desktop/issues');
                                     }}
                                 >
@@ -74,7 +74,7 @@ export default function About() {
                                     variant='light'
                                     className='my-[5px]'
                                     size='sm'
-                                    onClick={() => {
+                                    onPress={() => {
                                         open('mailto:support@pot-app.com');
                                     }}
                                 >
@@ -105,7 +105,7 @@ export default function About() {
                                         variant='light'
                                         className='my-[5px]'
                                         size='lg'
-                                        onClick={() => {
+                                        onPress={() => {
                                             open('https://pd.qq.com/s/akns94e1r');
                                         }}
                                     >
@@ -118,7 +118,7 @@ export default function About() {
                                         variant='light'
                                         className='my-[5px]'
                                         size='lg'
-                                        onClick={() => {
+                                        onPress={() => {
                                             open('https://pot-app.com/img/qq_group.png');
                                         }}
                                     >
@@ -131,7 +131,7 @@ export default function About() {
                                         variant='light'
                                         className='my-[5px]'
                                         size='lg'
-                                        onClick={() => {
+                                        onPress={() => {
                                             open('https://t.me/pot_app');
                                         }}
                                     >
@@ -144,7 +144,7 @@ export default function About() {
                                         variant='light'
                                         className='my-[5px]'
                                         size='lg'
-                                        onClick={() => {
+                                        onPress={() => {
                                             open('https://github.com/pot-app/pot-desktop/discussions');
                                         }}
                                     >
@@ -163,7 +163,7 @@ export default function About() {
                         variant='light'
                         className='my-[5px]'
                         size='sm'
-                        onClick={() => {
+                        onPress={() => {
                             invoke('updater_window');
                         }}
                     >
@@ -173,7 +173,7 @@ export default function About() {
                         variant='light'
                         className='my-[5px]'
                         size='sm'
-                        onClick={async () => {
+                        onPress={async () => {
                             const dir = await appLogDir();
                             open(dir);
                         }}
@@ -184,7 +184,7 @@ export default function About() {
                         variant='light'
                         className='my-[5px]'
                         size='sm'
-                        onClick={async () => {
+                        onPress={async () => {
                             const dir = await appConfigDir();
                             open(dir);
                         }}

--- a/src/window/Config/pages/Hotkey/index.jsx
+++ b/src/window/Config/pages/Hotkey/index.jsx
@@ -137,7 +137,7 @@ export default function Hotkey() {
                                     size='sm'
                                     variant='flat'
                                     className={`${selectionTranslate === '' && 'hidden'}`}
-                                    onClick={() => {
+                                    onPress={() => {
                                         registerHandler('hotkey_selection_translate', selectionTranslate);
                                     }}
                                 >
@@ -167,7 +167,7 @@ export default function Hotkey() {
                                     size='sm'
                                     variant='flat'
                                     className={`${inputTranslate === '' && 'hidden'}`}
-                                    onClick={() => {
+                                    onPress={() => {
                                         registerHandler('hotkey_input_translate', inputTranslate);
                                     }}
                                 >
@@ -197,7 +197,7 @@ export default function Hotkey() {
                                     size='sm'
                                     variant='flat'
                                     className={`${ocrRecognize === '' && 'hidden'}`}
-                                    onClick={() => {
+                                    onPress={() => {
                                         registerHandler('hotkey_ocr_recognize', ocrRecognize);
                                     }}
                                 >
@@ -227,7 +227,7 @@ export default function Hotkey() {
                                     size='sm'
                                     variant='flat'
                                     className={`${ocrTranslate === '' && 'hidden'}`}
-                                    onClick={() => {
+                                    onPress={() => {
                                         registerHandler('hotkey_ocr_translate', ocrTranslate);
                                     }}
                                 >

--- a/src/window/Config/pages/Service/Collection/ConfigModal/index.jsx
+++ b/src/window/Config/pages/Service/Collection/ConfigModal/index.jsx
@@ -60,7 +60,7 @@ export default function ConfigModal(props) {
                             <Button
                                 color='danger'
                                 variant='light'
-                                onClick={onClose}
+                                onPress={onClose}
                             >
                                 {t('common.cancel')}
                             </Button>

--- a/src/window/Config/pages/Service/Collection/SelectModal/index.jsx
+++ b/src/window/Config/pages/Service/Collection/SelectModal/index.jsx
@@ -47,7 +47,7 @@ export default function SelectModal(props) {
                             <Button
                                 color='danger'
                                 variant='light'
-                                onClick={onClose}
+                                onPress={onClose}
                             >
                                 {t('common.cancel')}
                             </Button>

--- a/src/window/Config/pages/Service/Collection/ServiceItem/index.jsx
+++ b/src/window/Config/pages/Service/Collection/ServiceItem/index.jsx
@@ -66,7 +66,7 @@ export default function ServiceItem(props) {
                     size='sm'
                     variant='light'
                     color='danger'
-                    onClick={() => {
+                    onPress={() => {
                         deleteService(name);
                     }}
                 >

--- a/src/window/Config/pages/Service/Recognize/ConfigModal/index.jsx
+++ b/src/window/Config/pages/Service/Recognize/ConfigModal/index.jsx
@@ -61,7 +61,7 @@ export default function ConfigModal(props) {
                             <Button
                                 color='danger'
                                 variant='light'
-                                onClick={onClose}
+                                onPress={onClose}
                             >
                                 {t('common.cancel')}
                             </Button>

--- a/src/window/Config/pages/Service/Recognize/SelectModal/index.jsx
+++ b/src/window/Config/pages/Service/Recognize/SelectModal/index.jsx
@@ -52,7 +52,7 @@ export default function SelectModal(props) {
                             <Button
                                 color='danger'
                                 variant='light'
-                                onClick={onClose}
+                                onPress={onClose}
                             >
                                 {t('common.cancel')}
                             </Button>

--- a/src/window/Config/pages/Service/Recognize/ServiceItem/index.jsx
+++ b/src/window/Config/pages/Service/Recognize/ServiceItem/index.jsx
@@ -67,7 +67,7 @@ export default function ServiceItem(props) {
                     size='sm'
                     variant='light'
                     color='danger'
-                    onClick={() => {
+                    onPress={() => {
                         deleteService(name);
                     }}
                 >

--- a/src/window/Config/pages/Service/SelectPluginModal/index.jsx
+++ b/src/window/Config/pages/Service/SelectPluginModal/index.jsx
@@ -125,7 +125,7 @@ export default function SelectPluginModal(props) {
                             <Button
                                 color='danger'
                                 variant='light'
-                                onClick={onClose}
+                                onPress={onClose}
                             >
                                 {t('common.cancel')}
                             </Button>

--- a/src/window/Config/pages/Service/Translate/ConfigModal/index.jsx
+++ b/src/window/Config/pages/Service/Translate/ConfigModal/index.jsx
@@ -60,7 +60,7 @@ export default function ConfigModal(props) {
                             <Button
                                 color='danger'
                                 variant='light'
-                                onClick={onClose}
+                                onPress={onClose}
                             >
                                 {t('common.cancel')}
                             </Button>

--- a/src/window/Config/pages/Service/Translate/SelectModal/index.jsx
+++ b/src/window/Config/pages/Service/Translate/SelectModal/index.jsx
@@ -47,7 +47,7 @@ export default function SelectModal(props) {
                             <Button
                                 color='danger'
                                 variant='light'
-                                onClick={onClose}
+                                onPress={onClose}
                             >
                                 {t('common.cancel')}
                             </Button>

--- a/src/window/Config/pages/Service/Translate/ServiceItem/index.jsx
+++ b/src/window/Config/pages/Service/Translate/ServiceItem/index.jsx
@@ -76,7 +76,7 @@ export default function ServiceItem(props) {
                         size='sm'
                         variant='light'
                         color='danger'
-                        onClick={() => {
+                        onPress={() => {
                             deleteService(name);
                         }}
                     >

--- a/src/window/Config/pages/Service/Tts/ConfigModal/index.jsx
+++ b/src/window/Config/pages/Service/Tts/ConfigModal/index.jsx
@@ -60,7 +60,7 @@ export default function ConfigModal(props) {
                             <Button
                                 color='danger'
                                 variant='light'
-                                onClick={onClose}
+                                onPress={onClose}
                             >
                                 {t('common.cancel')}
                             </Button>

--- a/src/window/Config/pages/Service/Tts/SelectModal/index.jsx
+++ b/src/window/Config/pages/Service/Tts/SelectModal/index.jsx
@@ -47,7 +47,7 @@ export default function SelectModal(props) {
                             <Button
                                 color='danger'
                                 variant='light'
-                                onClick={onClose}
+                                onPress={onClose}
                             >
                                 {t('common.cancel')}
                             </Button>

--- a/src/window/Config/pages/Service/Tts/ServiceItem/index.jsx
+++ b/src/window/Config/pages/Service/Tts/ServiceItem/index.jsx
@@ -66,7 +66,7 @@ export default function ServiceItem(props) {
                     size='sm'
                     variant='light'
                     color='danger'
-                    onClick={() => {
+                    onPress={() => {
                         deleteService(name);
                     }}
                 >

--- a/src/window/Updater/index.jsx
+++ b/src/window/Updater/index.jsx
@@ -154,7 +154,7 @@ export default function Updater() {
                     isLoading={downloaded !== 0}
                     isDisabled={downloaded !== 0}
                     color='primary'
-                    onClick={() => {
+                    onPress={() => {
                         installUpdate().then(
                             () => {
                                 toast.success(t('updater.installed'), { style: toastStyle });
@@ -174,7 +174,7 @@ export default function Updater() {
                 <Button
                     variant='flat'
                     color='danger'
-                    onClick={() => {
+                    onPress={() => {
                         appWindow.close();
                     }}
                 >


### PR DESCRIPTION
With this PR, users can submit form with 'Enter' key on the collections page while they are not focused on the 'save' button, not sure if it's a better option or not, if it is, we can refactor other pages too.

And according to the [NextUI Doc](https://nextui.org/docs/components/button), the 'onClick' already Deprecated, should use 'onPress' instead.