### PR TITLE
refactor: improve ux of config modal in translate pages

### DIFF
--- a/src/services/translate/alibaba/Config.jsx
+++ b/src/services/translate/alibaba/Config.jsx
@@ -26,7 +26,24 @@ export function Config(props) {
 
     return (
         config !== null && (
-            <>
+            <form
+                onSubmit={(e) => {
+                    e.preventDefault();
+                    setIsLoading(true);
+                    translate('hello', Language.auto, Language.zh_cn, { config }).then(
+                        () => {
+                            setIsLoading(false);
+                            setConfig(config, true);
+                            updateServiceList('alibaba');
+                            onClose();
+                        },
+                        (e) => {
+                            setIsLoading(false);
+                            toast.error(t('config.service.test_failed') + e.toString(), { style: toastStyle });
+                        }
+                    );
+                }}
+            >
                 <Toaster />
                 <div className={'config-item'}>
                     <h3 className='my-auto'>{t('services.help')}</h3>
@@ -39,11 +56,16 @@ export function Config(props) {
                     </Button>
                 </div>
                 <div className={'config-item'}>
-                    <h3 className='my-auto'>{t('services.translate.alibaba.accesskey_id')}</h3>
                     <Input
+                        label={t('services.translate.alibaba.accesskey_id')}
+                        labelPlacement='outside-left'
                         value={config['accesskey_id']}
                         variant='bordered'
-                        className='max-w-[50%]'
+                        classNames={{
+                            base: 'justify-between',
+                            label: 'text-[length:--nextui-font-size-medium]',
+                            mainWrapper: 'max-w-[50%]',
+                        }}
                         onValueChange={(value) => {
                             setConfig({
                                 ...config,
@@ -53,11 +75,16 @@ export function Config(props) {
                     />
                 </div>
                 <div className={'config-item'}>
-                    <h3 className='my-auto'>{t('services.translate.alibaba.accesskey_secret')}</h3>
                     <Input
+                        label={t('services.translate.alibaba.accesskey_secret')}
+                        labelPlacement='outside-left'
                         value={config['accesskey_secret']}
                         variant='bordered'
-                        className='max-w-[50%]'
+                        classNames={{
+                            base: 'justify-between',
+                            label: 'text-[length:--nextui-font-size-medium]',
+                            mainWrapper: 'max-w-[50%]',
+                        }}
                         onValueChange={(value) => {
                             setConfig({
                                 ...config,
@@ -66,31 +93,15 @@ export function Config(props) {
                         }}
                     />
                 </div>
-                <div>
-                    <Button
-                        isLoading={isLoading}
-                        color='primary'
-                        fullWidth
-                        onPress={() => {
-                            setIsLoading(true);
-                            translate('hello', Language.auto, Language.zh_cn, { config }).then(
-                                () => {
-                                    setIsLoading(false);
-                                    setConfig(config, true);
-                                    updateServiceList('alibaba');
-                                    onClose();
-                                },
-                                (e) => {
-                                    setIsLoading(false);
-                                    toast.error(t('config.service.test_failed') + e.toString(), { style: toastStyle });
-                                }
-                            );
-                        }}
-                    >
-                        {t('common.save')}
-                    </Button>
-                </div>
-            </>
+                <Button
+                    type='submit'
+                    isLoading={isLoading}
+                    color='primary'
+                    fullWidth
+                >
+                    {t('common.save')}
+                </Button>
+            </form>
         )
     );
 }

--- a/src/services/translate/baidu/Config.jsx
+++ b/src/services/translate/baidu/Config.jsx
@@ -26,7 +26,24 @@ export function Config(props) {
 
     return (
         config !== null && (
-            <>
+            <form
+                onSubmit={(e) => {
+                    e.preventDefault();
+                    setIsLoading(true);
+                    translate('hello', Language.auto, Language.zh_cn, { config }).then(
+                        () => {
+                            setIsLoading(false);
+                            setConfig(config, true);
+                            updateServiceList('baidu');
+                            onClose();
+                        },
+                        (e) => {
+                            setIsLoading(false);
+                            toast.error(t('config.service.test_failed') + e.toString(), { style: toastStyle });
+                        }
+                    );
+                }}
+            >
                 <Toaster />
                 <div className={'config-item'}>
                     <h3 className='my-auto'>{t('services.help')}</h3>
@@ -38,13 +55,17 @@ export function Config(props) {
                         {t('services.help')}
                     </Button>
                 </div>
-
                 <div className={'config-item'}>
-                    <h3 className='my-auto'>{t('services.translate.baidu.appid')}</h3>
                     <Input
+                        label={t('services.translate.baidu.appid')}
+                        labelPlacement='outside-left'
                         value={config['appid']}
                         variant='bordered'
-                        className='max-w-[50%]'
+                        classNames={{
+                            base: 'justify-between',
+                            label: 'text-[length:--nextui-font-size-medium]',
+                            mainWrapper: 'max-w-[50%]',
+                        }}
                         onValueChange={(value) => {
                             setConfig({
                                 ...config,
@@ -54,11 +75,16 @@ export function Config(props) {
                     />
                 </div>
                 <div className={'config-item'}>
-                    <h3 className='my-auto'>{t('services.translate.baidu.secret')}</h3>
                     <Input
+                        label={t('services.translate.baidu.secret')}
+                        labelPlacement='outside-left'
                         value={config['secret']}
                         variant='bordered'
-                        className='max-w-[50%]'
+                        classNames={{
+                            base: 'justify-between',
+                            label: 'text-[length:--nextui-font-size-medium]',
+                            mainWrapper: 'max-w-[50%]',
+                        }}
                         onValueChange={(value) => {
                             setConfig({
                                 ...config,
@@ -67,31 +93,15 @@ export function Config(props) {
                         }}
                     />
                 </div>
-                <div>
-                    <Button
-                        isLoading={isLoading}
-                        color='primary'
-                        fullWidth
-                        onPress={() => {
-                            setIsLoading(true);
-                            translate('hello', Language.auto, Language.zh_cn, { config }).then(
-                                () => {
-                                    setIsLoading(false);
-                                    setConfig(config, true);
-                                    updateServiceList('baidu');
-                                    onClose();
-                                },
-                                (e) => {
-                                    setIsLoading(false);
-                                    toast.error(t('config.service.test_failed') + e.toString(), { style: toastStyle });
-                                }
-                            );
-                        }}
-                    >
-                        {t('common.save')}
-                    </Button>
-                </div>
-            </>
+                <Button
+                    type='submit'
+                    isLoading={isLoading}
+                    color='primary'
+                    fullWidth
+                >
+                    {t('common.save')}
+                </Button>
+            </form>
         )
     );
 }

--- a/src/services/translate/baidu_field/Config.jsx
+++ b/src/services/translate/baidu_field/Config.jsx
@@ -43,7 +43,24 @@ export function Config(props) {
 
     return (
         config !== null && (
-            <>
+            <form
+                onSubmit={(e) => {
+                    e.preventDefault();
+                    setIsLoading(true);
+                    translate('hello', Language.auto, Language.zh_cn, { config }).then(
+                        () => {
+                            setIsLoading(false);
+                            setConfig(config, true);
+                            updateServiceList('baidu_field');
+                            onClose();
+                        },
+                        (e) => {
+                            setIsLoading(false);
+                            toast.error(t('config.service.test_failed') + e.toString(), { style: toastStyle });
+                        }
+                    );
+                }}
+            >
                 <Toaster />
                 <div className={'config-item'}>
                     <h3 className='my-auto'>{t('services.help')}</h3>
@@ -62,6 +79,7 @@ export function Config(props) {
                             <Button variant='bordered'>{t(`services.translate.baidu_field.${config.field}`)}</Button>
                         </DropdownTrigger>
                         <DropdownMenu
+                            autoFocus='first'
                             aria-label='app language'
                             className='max-h-[50vh] overflow-y-auto'
                             onAction={(key) => {
@@ -82,11 +100,16 @@ export function Config(props) {
                     </Dropdown>
                 </div>
                 <div className={'config-item'}>
-                    <h3 className='my-auto'>{t('services.translate.baidu.appid')}</h3>
                     <Input
+                        label={t('services.translate.baidu.appid')}
+                        labelPlacement='outside-left'
                         value={config['appid']}
                         variant='bordered'
-                        className='max-w-[50%]'
+                        classNames={{
+                            base: 'justify-between',
+                            label: 'text-[length:--nextui-font-size-medium]',
+                            mainWrapper: 'max-w-[50%]',
+                        }}
                         onValueChange={(value) => {
                             setConfig({
                                 ...config,
@@ -96,11 +119,16 @@ export function Config(props) {
                     />
                 </div>
                 <div className={'config-item'}>
-                    <h3 className='my-auto'>{t('services.translate.baidu.secret')}</h3>
                     <Input
+                        label={t('services.translate.baidu.secret')}
+                        labelPlacement='outside-left'
                         value={config['secret']}
                         variant='bordered'
-                        className='max-w-[50%]'
+                        classNames={{
+                            base: 'justify-between',
+                            label: 'text-[length:--nextui-font-size-medium]',
+                            mainWrapper: 'max-w-[50%]',
+                        }}
                         onValueChange={(value) => {
                             setConfig({
                                 ...config,
@@ -109,31 +137,15 @@ export function Config(props) {
                         }}
                     />
                 </div>
-                <div>
-                    <Button
-                        isLoading={isLoading}
-                        color='primary'
-                        fullWidth
-                        onPress={() => {
-                            setIsLoading(true);
-                            translate('hello', Language.auto, Language.zh_cn, { config }).then(
-                                () => {
-                                    setIsLoading(false);
-                                    setConfig(config, true);
-                                    updateServiceList('baidu_field');
-                                    onClose();
-                                },
-                                (e) => {
-                                    setIsLoading(false);
-                                    toast.error(t('config.service.test_failed') + e.toString(), { style: toastStyle });
-                                }
-                            );
-                        }}
-                    >
-                        {t('common.save')}
-                    </Button>
-                </div>
-            </>
+                <Button
+                    type='submit'
+                    isLoading={isLoading}
+                    color='primary'
+                    fullWidth
+                >
+                    {t('common.save')}
+                </Button>
+            </form>
         )
     );
 }

--- a/src/services/translate/caiyun/Config.jsx
+++ b/src/services/translate/caiyun/Config.jsx
@@ -25,7 +25,24 @@ export function Config(props) {
 
     return (
         config !== null && (
-            <>
+            <form
+                onSubmit={(e) => {
+                    e.preventDefault();
+                    setIsLoading(true);
+                    translate('hello', Language.auto, Language.zh_cn, { config }).then(
+                        () => {
+                            setIsLoading(false);
+                            setConfig(config, true);
+                            updateServiceList('caiyun');
+                            onClose();
+                        },
+                        (e) => {
+                            setIsLoading(false);
+                            toast.error(t('config.service.test_failed') + e.toString(), { style: toastStyle });
+                        }
+                    );
+                }}
+            >
                 <Toaster />
                 <div className={'config-item'}>
                     <h3 className='my-auto'>{t('services.help')}</h3>
@@ -38,11 +55,16 @@ export function Config(props) {
                     </Button>
                 </div>
                 <div className={'config-item'}>
-                    <h3 className='my-auto'>{t('services.translate.caiyun.token')}</h3>
                     <Input
+                        label={t('services.translate.caiyun.token')}
+                        labelPlacement='outside-left'
                         value={config['token']}
                         variant='bordered'
-                        className='max-w-[50%]'
+                        classNames={{
+                            base: 'justify-between',
+                            label: 'text-[length:--nextui-font-size-medium]',
+                            mainWrapper: 'max-w-[50%]',
+                        }}
                         onValueChange={(value) => {
                             setConfig({
                                 ...config,
@@ -51,31 +73,15 @@ export function Config(props) {
                         }}
                     />
                 </div>
-                <div>
-                    <Button
-                        isLoading={isLoading}
-                        color='primary'
-                        fullWidth
-                        onPress={() => {
-                            setIsLoading(true);
-                            translate('hello', Language.auto, Language.zh_cn, { config }).then(
-                                () => {
-                                    setIsLoading(false);
-                                    setConfig(config, true);
-                                    updateServiceList('caiyun');
-                                    onClose();
-                                },
-                                (e) => {
-                                    setIsLoading(false);
-                                    toast.error(t('config.service.test_failed') + e.toString(), { style: toastStyle });
-                                }
-                            );
-                        }}
-                    >
-                        {t('common.save')}
-                    </Button>
-                </div>
-            </>
+                <Button
+                    type='submit'
+                    isLoading={isLoading}
+                    color='primary'
+                    fullWidth
+                >
+                    {t('common.save')}
+                </Button>
+            </form>
         )
     );
 }

--- a/src/services/translate/deepl/Config.jsx
+++ b/src/services/translate/deepl/Config.jsx
@@ -31,7 +31,24 @@ export function Config(props) {
 
     return (
         deeplConfig !== null && (
-            <>
+            <form
+                onSubmit={(e) => {
+                    e.preventDefault();
+                    setIsLoading(true);
+                    translate('hello', Language.auto, Language.zh_cn, { config: deeplConfig }).then(
+                        () => {
+                            setIsLoading(false);
+                            setDeeplConfig(deeplConfig, true);
+                            updateServiceList('deepl');
+                            onClose();
+                        },
+                        (e) => {
+                            setIsLoading(false);
+                            toast.error(t('config.service.test_failed') + e.toString(), { style: toastStyle });
+                        }
+                    );
+                }}
+            >
                 <Toaster />
                 <div className={`config-item ${deeplConfig.type === 'free' && 'hidden'}`}>
                     <h3 className='my-auto'>{t('services.help')}</h3>
@@ -54,6 +71,7 @@ export function Config(props) {
                             <Button variant='bordered'>{t(`services.translate.deepl.${deeplConfig.type}`)}</Button>
                         </DropdownTrigger>
                         <DropdownMenu
+                            autoFocus='first'
                             aria-label='app language'
                             onAction={(key) => {
                                 setDeeplConfig({
@@ -69,12 +87,17 @@ export function Config(props) {
                     </Dropdown>
                 </div>
                 <div className={`config-item ${deeplConfig.type !== 'api' && 'hidden'}`}>
-                    <h3 className='my-auto'>{t('services.translate.deepl.auth_key')}</h3>
                     <Input
+                        label={t('services.translate.deepl.auth_key')}
+                        labelPlacement='outside-left'
                         type='password'
                         value={deeplConfig['authKey']}
                         variant='bordered'
-                        className='max-w-[50%]'
+                        classNames={{
+                            base: 'justify-between',
+                            label: 'text-[length:--nextui-font-size-medium]',
+                            mainWrapper: 'max-w-[50%]',
+                        }}
                         onValueChange={(value) => {
                             setDeeplConfig({
                                 ...deeplConfig,
@@ -84,11 +107,16 @@ export function Config(props) {
                     />
                 </div>
                 <div className={`config-item ${deeplConfig.type !== 'deeplx' && 'hidden'}`}>
-                    <h3 className='my-auto'>{t('services.translate.deepl.custom_url')}</h3>
                     <Input
+                        label={t('services.translate.deepl.custom_url')}
+                        labelPlacement='outside-left'
                         value={deeplConfig.customUrl}
                         variant='bordered'
-                        className='max-w-[50%]'
+                        classNames={{
+                            base: 'justify-between',
+                            label: 'text-[length:--nextui-font-size-medium]',
+                            mainWrapper: 'max-w-[50%]',
+                        }}
                         onValueChange={(value) => {
                             setDeeplConfig({
                                 ...deeplConfig,
@@ -97,31 +125,15 @@ export function Config(props) {
                         }}
                     />
                 </div>
-                <div>
-                    <Button
-                        isLoading={isLoading}
-                        color='primary'
-                        fullWidth
-                        onPress={() => {
-                            setIsLoading(true);
-                            translate('hello', Language.auto, Language.zh_cn, { config: deeplConfig }).then(
-                                () => {
-                                    setIsLoading(false);
-                                    setDeeplConfig(deeplConfig, true);
-                                    updateServiceList('deepl');
-                                    onClose();
-                                },
-                                (e) => {
-                                    setIsLoading(false);
-                                    toast.error(t('config.service.test_failed') + e.toString(), { style: toastStyle });
-                                }
-                            );
-                        }}
-                    >
-                        {t('common.save')}
-                    </Button>
-                </div>
-            </>
+                <Button
+                    type='submit'
+                    isLoading={isLoading}
+                    color='primary'
+                    fullWidth
+                >
+                    {t('common.save')}
+                </Button>
+            </form>
         )
     );
 }

--- a/src/services/translate/google/Config.jsx
+++ b/src/services/translate/google/Config.jsx
@@ -24,14 +24,36 @@ export function Config(props) {
 
     return (
         config !== null && (
-            <>
+            <form
+                onSubmit={(e) => {
+                    e.preventDefault();
+                    setIsLoading(true);
+                    translate('hello', Language.auto, Language.zh_cn, { config }).then(
+                        () => {
+                            setIsLoading(false);
+                            setConfig(config, true);
+                            updateServiceList('google');
+                            onClose();
+                        },
+                        (e) => {
+                            setIsLoading(false);
+                            toast.error(t('config.service.test_failed') + e.toString(), { style: toastStyle });
+                        }
+                    );
+                }}
+            >
                 <Toaster />
                 <div className={'config-item'}>
-                    <h3 className='my-auto'>{t('services.translate.google.custom_url')}</h3>
                     <Input
+                        label={t('services.translate.google.custom_url')}
+                        labelPlacement='outside-left'
                         value={config['custom_url']}
                         variant='bordered'
-                        className='max-w-[50%]'
+                        classNames={{
+                            base: 'justify-between',
+                            label: 'text-[length:--nextui-font-size-medium]',
+                            mainWrapper: 'max-w-[50%]',
+                        }}
                         onValueChange={(value) => {
                             setConfig({
                                 ...config,
@@ -40,31 +62,15 @@ export function Config(props) {
                         }}
                     />
                 </div>
-                <div>
-                    <Button
-                        isLoading={isLoading}
-                        color='primary'
-                        fullWidth
-                        onPress={() => {
-                            setIsLoading(true);
-                            translate('hello', Language.auto, Language.zh_cn, { config }).then(
-                                () => {
-                                    setIsLoading(false);
-                                    setConfig(config, true);
-                                    updateServiceList('google');
-                                    onClose();
-                                },
-                                (e) => {
-                                    setIsLoading(false);
-                                    toast.error(t('config.service.test_failed') + e.toString(), { style: toastStyle });
-                                }
-                            );
-                        }}
-                    >
-                        {t('common.save')}
-                    </Button>
-                </div>
-            </>
+                <Button
+                    type='submit'
+                    isLoading={isLoading}
+                    color='primary'
+                    fullWidth
+                >
+                    {t('common.save')}
+                </Button>
+            </form>
         )
     );
 }

--- a/src/services/translate/niutrans/Config.jsx
+++ b/src/services/translate/niutrans/Config.jsx
@@ -26,7 +26,24 @@ export function Config(props) {
 
     return (
         config !== null && (
-            <>
+            <form
+                onSubmit={(e) => {
+                    e.preventDefault();
+                    setIsLoading(true);
+                    translate('hello', Language.auto, Language.zh_cn, { config }).then(
+                        () => {
+                            setIsLoading(false);
+                            setConfig(config, true);
+                            updateServiceList('niutrans');
+                            onClose();
+                        },
+                        (e) => {
+                            setIsLoading(false);
+                            toast.error(t('config.service.test_failed') + e.toString(), { style: toastStyle });
+                        }
+                    );
+                }}
+            >
                 <Toaster />
                 <div className={'config-item'}>
                     <h3 className='my-auto'>{t('services.help')}</h3>
@@ -39,20 +56,29 @@ export function Config(props) {
                     </Button>
                 </div>
                 <div className={'config-item'}>
-                    <h3 className='my-auto'>{t('services.translate.niutrans.https')}</h3>
                     <Switch
                         isSelected={config['https'] ?? true}
                         onValueChange={(v) => {
                             setConfig({ ...config, https: v });
                         }}
-                    />
+                        classNames={{
+                            base: 'flex flex-row-reverse justify-between w-full max-w-full',
+                        }}
+                    >
+                        {t('services.translate.niutrans.https')}
+                    </Switch>
                 </div>
                 <div className={'config-item'}>
-                    <h3 className='my-auto'>{t('services.translate.niutrans.apikey')}</h3>
                     <Input
+                        label={t('services.translate.niutrans.apikey')}
+                        labelPlacement='outside-left'
                         value={config['apikey']}
                         variant='bordered'
-                        className='max-w-[50%]'
+                        classNames={{
+                            base: 'justify-between',
+                            label: 'text-[length:--nextui-font-size-medium]',
+                            mainWrapper: 'max-w-[50%]',
+                        }}
                         onValueChange={(value) => {
                             setConfig({
                                 ...config,
@@ -61,31 +87,15 @@ export function Config(props) {
                         }}
                     />
                 </div>
-                <div>
-                    <Button
-                        isLoading={isLoading}
-                        color='primary'
-                        fullWidth
-                        onPress={() => {
-                            setIsLoading(true);
-                            translate('hello', Language.auto, Language.zh_cn, { config }).then(
-                                () => {
-                                    setIsLoading(false);
-                                    setConfig(config, true);
-                                    updateServiceList('niutrans');
-                                    onClose();
-                                },
-                                (e) => {
-                                    setIsLoading(false);
-                                    toast.error(t('config.service.test_failed') + e.toString(), { style: toastStyle });
-                                }
-                            );
-                        }}
-                    >
-                        {t('common.save')}
-                    </Button>
-                </div>
-            </>
+                <Button
+                    type='submit'
+                    isLoading={isLoading}
+                    color='primary'
+                    fullWidth
+                >
+                    {t('common.save')}
+                </Button>
+            </form>
         )
     );
 }

--- a/src/services/translate/openai/Config.jsx
+++ b/src/services/translate/openai/Config.jsx
@@ -35,7 +35,24 @@ export function Config(props) {
 
     return (
         openaiConfig !== null && (
-            <>
+            <form
+                onSubmit={(e) => {
+                    e.preventDefault();
+                    setIsLoading(true);
+                    translate('hello', Language.auto, Language.zh_cn, { config: openaiConfig }).then(
+                        () => {
+                            setIsLoading(false);
+                            setOpenaiConfig(openaiConfig, true);
+                            updateServiceList('openai');
+                            onClose();
+                        },
+                        (e) => {
+                            setIsLoading(false);
+                            toast.error(t('config.service.test_failed') + e.toString(), { style: toastStyle });
+                        }
+                    );
+                }}
+            >
                 <Toaster />
                 <div className='config-item'>
                     <h3 className='my-auto'>{t('services.help')}</h3>
@@ -54,6 +71,7 @@ export function Config(props) {
                             <Button variant='bordered'>{t(`services.translate.openai.${openaiConfig.service}`)}</Button>
                         </DropdownTrigger>
                         <DropdownMenu
+                            autoFocus='first'
                             aria-label='service'
                             onAction={(key) => {
                                 setOpenaiConfig({
@@ -68,7 +86,6 @@ export function Config(props) {
                     </Dropdown>
                 </div>
                 <div className='config-item'>
-                    <h3 className='my-auto'>{t('services.translate.openai.stream')}</h3>
                     <Switch
                         isSelected={openaiConfig['stream']}
                         onValueChange={(value) => {
@@ -77,14 +94,24 @@ export function Config(props) {
                                 stream: value,
                             });
                         }}
-                    />
+                        classNames={{
+                            base: 'flex flex-row-reverse justify-between w-full max-w-full',
+                        }}
+                    >
+                        {t('services.translate.openai.stream')}
+                    </Switch>
                 </div>
                 <div className='config-item'>
-                    <h3 className='my-auto'>{t('services.translate.openai.request_path')}</h3>
                     <Input
+                        label={t('services.translate.openai.request_path')}
+                        labelPlacement='outside-left'
                         value={openaiConfig['requestPath']}
                         variant='bordered'
-                        className='max-w-[50%]'
+                        classNames={{
+                            base: 'justify-between',
+                            label: 'text-[length:--nextui-font-size-medium]',
+                            mainWrapper: 'max-w-[50%]',
+                        }}
                         onValueChange={(value) => {
                             setOpenaiConfig({
                                 ...openaiConfig,
@@ -93,13 +120,18 @@ export function Config(props) {
                         }}
                     />
                 </div>
-                <div className='config-item '>
-                    <h3 className='my-auto'>{t('services.translate.openai.api_key')}</h3>
+                <div className='config-item'>
                     <Input
+                        label={t('services.translate.openai.api_key')}
+                        labelPlacement='outside-left'
                         type='password'
                         value={openaiConfig['apiKey']}
                         variant='bordered'
-                        className='max-w-[50%]'
+                        classNames={{
+                            base: 'justify-between',
+                            label: 'text-[length:--nextui-font-size-medium]',
+                            mainWrapper: 'max-w-[50%]',
+                        }}
                         onValueChange={(value) => {
                             setOpenaiConfig({
                                 ...openaiConfig,
@@ -115,6 +147,7 @@ export function Config(props) {
                             <Button variant='bordered'>{openaiConfig.model}</Button>
                         </DropdownTrigger>
                         <DropdownMenu
+                            autoFocus='first'
                             aria-label='service'
                             onAction={(key) => {
                                 setOpenaiConfig({
@@ -130,7 +163,7 @@ export function Config(props) {
                         </DropdownMenu>
                     </Dropdown>
                 </div>
-                <div className='config-item '>
+                <div className='config-item'>
                     <Textarea
                         label={t('services.translate.openai.system_prompt')}
                         labelPlacement='outside'
@@ -146,7 +179,7 @@ export function Config(props) {
                         }}
                     />
                 </div>
-                <div className='config-item '>
+                <div className='config-item'>
                     <Textarea
                         label={t('services.translate.openai.user_prompt')}
                         className='mb-3'
@@ -163,31 +196,15 @@ export function Config(props) {
                         }}
                     />
                 </div>
-                <div>
-                    <Button
-                        isLoading={isLoading}
-                        fullWidth
-                        color='primary'
-                        onPress={() => {
-                            setIsLoading(true);
-                            translate('hello', Language.auto, Language.zh_cn, { config: openaiConfig }).then(
-                                () => {
-                                    setIsLoading(false);
-                                    setOpenaiConfig(openaiConfig, true);
-                                    updateServiceList('openai');
-                                    onClose();
-                                },
-                                (e) => {
-                                    setIsLoading(false);
-                                    toast.error(t('config.service.test_failed') + e.toString(), { style: toastStyle });
-                                }
-                            );
-                        }}
-                    >
-                        {t('common.save')}
-                    </Button>
-                </div>
-            </>
+                <Button
+                    type='submit'
+                    isLoading={isLoading}
+                    fullWidth
+                    color='primary'
+                >
+                    {t('common.save')}
+                </Button>
+            </form>
         )
     );
 }

--- a/src/services/translate/openai_custom/Config.jsx
+++ b/src/services/translate/openai_custom/Config.jsx
@@ -35,7 +35,24 @@ export function Config(props) {
 
     return (
         openaiConfig !== null && (
-            <>
+            <form
+                onSubmit={(e) => {
+                    e.preventDefault();
+                    setIsLoading(true);
+                    translate('hello', Language.auto, Language.zh_cn, { config: openaiConfig }).then(
+                        () => {
+                            setIsLoading(false);
+                            setOpenaiConfig(openaiConfig, true);
+                            updateServiceList('openai_custom');
+                            onClose();
+                        },
+                        (e) => {
+                            setIsLoading(false);
+                            toast.error(t('config.service.test_failed') + e.toString(), { style: toastStyle });
+                        }
+                    );
+                }}
+            >
                 <Toaster />
                 <div className='config-item'>
                     <h3 className='my-auto'>{t('services.help')}</h3>
@@ -54,6 +71,7 @@ export function Config(props) {
                             <Button variant='bordered'>{t(`services.translate.openai.${openaiConfig.service}`)}</Button>
                         </DropdownTrigger>
                         <DropdownMenu
+                            autoFocus='first'
                             aria-label='service'
                             onAction={(key) => {
                                 setOpenaiConfig({
@@ -68,7 +86,6 @@ export function Config(props) {
                     </Dropdown>
                 </div>
                 <div className='config-item'>
-                    <h3 className='my-auto'>{t('services.translate.openai.stream')}</h3>
                     <Switch
                         isSelected={openaiConfig['stream']}
                         onValueChange={(value) => {
@@ -77,14 +94,24 @@ export function Config(props) {
                                 stream: value,
                             });
                         }}
-                    />
+                        classNames={{
+                            base: 'flex flex-row-reverse justify-between w-full max-w-full',
+                        }}
+                    >
+                        {t('services.translate.openai.stream')}
+                    </Switch>
                 </div>
                 <div className='config-item'>
-                    <h3 className='my-auto'>{t('services.translate.openai.request_path')}</h3>
                     <Input
+                        label={t('services.translate.openai.request_path')}
+                        labelPlacement='outside-left'
                         value={openaiConfig['requestPath']}
                         variant='bordered'
-                        className='max-w-[50%]'
+                        classNames={{
+                            base: 'justify-between',
+                            label: 'text-[length:--nextui-font-size-medium]',
+                            mainWrapper: 'max-w-[50%]',
+                        }}
                         onValueChange={(value) => {
                             setOpenaiConfig({
                                 ...openaiConfig,
@@ -93,13 +120,18 @@ export function Config(props) {
                         }}
                     />
                 </div>
-                <div className='config-item '>
-                    <h3 className='my-auto'>{t('services.translate.openai.api_key')}</h3>
+                <div className='config-item'>
                     <Input
+                        label={t('services.translate.openai.api_key')}
+                        labelPlacement='outside-left'
                         type='password'
                         value={openaiConfig['apiKey']}
                         variant='bordered'
-                        className='max-w-[50%]'
+                        classNames={{
+                            base: 'justify-between',
+                            label: 'text-[length:--nextui-font-size-medium]',
+                            mainWrapper: 'max-w-[50%]',
+                        }}
                         onValueChange={(value) => {
                             setOpenaiConfig({
                                 ...openaiConfig,
@@ -115,6 +147,7 @@ export function Config(props) {
                             <Button variant='bordered'>{openaiConfig.model}</Button>
                         </DropdownTrigger>
                         <DropdownMenu
+                            autoFocus='first'
                             aria-label='service'
                             onAction={(key) => {
                                 setOpenaiConfig({
@@ -130,7 +163,7 @@ export function Config(props) {
                         </DropdownMenu>
                     </Dropdown>
                 </div>
-                <div className='config-item '>
+                <div className='config-item'>
                     <Textarea
                         label={t('services.translate.openai.system_prompt')}
                         labelPlacement='outside'
@@ -145,7 +178,7 @@ export function Config(props) {
                         }}
                     />
                 </div>
-                <div className='config-item '>
+                <div className='config-item'>
                     <Textarea
                         label={t('services.translate.openai.user_prompt')}
                         className='mb-3'
@@ -161,31 +194,15 @@ export function Config(props) {
                         }}
                     />
                 </div>
-                <div>
-                    <Button
-                        isLoading={isLoading}
-                        fullWidth
-                        color='primary'
-                        onPress={() => {
-                            setIsLoading(true);
-                            translate('hello', Language.auto, Language.zh_cn, { config: openaiConfig }).then(
-                                () => {
-                                    setIsLoading(false);
-                                    setOpenaiConfig(openaiConfig, true);
-                                    updateServiceList('openai_custom');
-                                    onClose();
-                                },
-                                (e) => {
-                                    setIsLoading(false);
-                                    toast.error(t('config.service.test_failed') + e.toString(), { style: toastStyle });
-                                }
-                            );
-                        }}
-                    >
-                        {t('common.save')}
-                    </Button>
-                </div>
-            </>
+                <Button
+                    type='submit'
+                    isLoading={isLoading}
+                    fullWidth
+                    color='primary'
+                >
+                    {t('common.save')}
+                </Button>
+            </form>
         )
     );
 }

--- a/src/services/translate/openai_polish/Config.jsx
+++ b/src/services/translate/openai_polish/Config.jsx
@@ -35,7 +35,24 @@ export function Config(props) {
 
     return (
         openaiConfig !== null && (
-            <>
+            <form
+                onSubmit={(e) => {
+                    e.preventDefault();
+                    setIsLoading(true);
+                    translate('hello', Language.auto, Language.zh_cn, { config: openaiConfig }).then(
+                        () => {
+                            setIsLoading(false);
+                            setOpenaiConfig(openaiConfig, true);
+                            updateServiceList('openai_polish');
+                            onClose();
+                        },
+                        (e) => {
+                            setIsLoading(false);
+                            toast.error(t('config.service.test_failed') + e.toString(), { style: toastStyle });
+                        }
+                    );
+                }}
+            >
                 <Toaster />
                 <div className='config-item'>
                     <h3 className='my-auto'>{t('services.help')}</h3>
@@ -54,6 +71,7 @@ export function Config(props) {
                             <Button variant='bordered'>{t(`services.translate.openai.${openaiConfig.service}`)}</Button>
                         </DropdownTrigger>
                         <DropdownMenu
+                            autoFocus='first'
                             aria-label='service'
                             onAction={(key) => {
                                 setOpenaiConfig({
@@ -68,7 +86,6 @@ export function Config(props) {
                     </Dropdown>
                 </div>
                 <div className='config-item'>
-                    <h3 className='my-auto'>{t('services.translate.openai.stream')}</h3>
                     <Switch
                         isSelected={openaiConfig['stream']}
                         onValueChange={(value) => {
@@ -77,14 +94,24 @@ export function Config(props) {
                                 stream: value,
                             });
                         }}
-                    />
+                        classNames={{
+                            base: 'flex flex-row-reverse justify-between w-full max-w-full',
+                        }}
+                    >
+                        {t('services.translate.openai.stream')}
+                    </Switch>
                 </div>
                 <div className='config-item'>
-                    <h3 className='my-auto'>{t('services.translate.openai.request_path')}</h3>
                     <Input
+                        label={t('services.translate.openai.request_path')}
+                        labelPlacement='outside-left'
                         value={openaiConfig['requestPath']}
                         variant='bordered'
-                        className='max-w-[50%]'
+                        classNames={{
+                            base: 'justify-between',
+                            label: 'text-[length:--nextui-font-size-medium]',
+                            mainWrapper: 'max-w-[50%]',
+                        }}
                         onValueChange={(value) => {
                             setOpenaiConfig({
                                 ...openaiConfig,
@@ -93,13 +120,18 @@ export function Config(props) {
                         }}
                     />
                 </div>
-                <div className='config-item '>
-                    <h3 className='my-auto'>{t('services.translate.openai.api_key')}</h3>
+                <div className='config-item'>
                     <Input
+                        label={t('services.translate.openai.api_key')}
+                        labelPlacement='outside-left'
                         type='password'
                         value={openaiConfig['apiKey']}
                         variant='bordered'
-                        className='max-w-[50%]'
+                        classNames={{
+                            base: 'justify-between',
+                            label: 'text-[length:--nextui-font-size-medium]',
+                            mainWrapper: 'max-w-[50%]',
+                        }}
                         onValueChange={(value) => {
                             setOpenaiConfig({
                                 ...openaiConfig,
@@ -115,6 +147,7 @@ export function Config(props) {
                             <Button variant='bordered'>{openaiConfig.model}</Button>
                         </DropdownTrigger>
                         <DropdownMenu
+                            autoFocus='first'
                             aria-label='service'
                             onAction={(key) => {
                                 setOpenaiConfig({
@@ -130,7 +163,7 @@ export function Config(props) {
                         </DropdownMenu>
                     </Dropdown>
                 </div>
-                <div className='config-item '>
+                <div className='config-item'>
                     <Textarea
                         label={t('services.translate.openai.system_prompt')}
                         labelPlacement='outside'
@@ -146,7 +179,7 @@ export function Config(props) {
                         }}
                     />
                 </div>
-                <div className='config-item '>
+                <div className='config-item'>
                     <Textarea
                         label={t('services.translate.openai.user_prompt')}
                         className='mb-3'
@@ -163,31 +196,15 @@ export function Config(props) {
                         }}
                     />
                 </div>
-                <div>
-                    <Button
-                        isLoading={isLoading}
-                        fullWidth
-                        color='primary'
-                        onPress={() => {
-                            setIsLoading(true);
-                            translate('hello', Language.auto, Language.zh_cn, { config: openaiConfig }).then(
-                                () => {
-                                    setIsLoading(false);
-                                    setOpenaiConfig(openaiConfig, true);
-                                    updateServiceList('openai_polish');
-                                    onClose();
-                                },
-                                (e) => {
-                                    setIsLoading(false);
-                                    toast.error(t('config.service.test_failed') + e.toString(), { style: toastStyle });
-                                }
-                            );
-                        }}
-                    >
-                        {t('common.save')}
-                    </Button>
-                </div>
-            </>
+                <Button
+                    type='submit'
+                    isLoading={isLoading}
+                    fullWidth
+                    color='primary'
+                >
+                    {t('common.save')}
+                </Button>
+            </form>
         )
     );
 }

--- a/src/services/translate/openai_summary/Config.jsx
+++ b/src/services/translate/openai_summary/Config.jsx
@@ -35,7 +35,24 @@ export function Config(props) {
 
     return (
         openaiConfig !== null && (
-            <>
+            <form
+                onSubmit={(e) => {
+                    e.preventDefault();
+                    setIsLoading(true);
+                    translate('hello', Language.auto, Language.zh_cn, { config: openaiConfig }).then(
+                        () => {
+                            setIsLoading(false);
+                            setOpenaiConfig(openaiConfig, true);
+                            updateServiceList('openai_summary');
+                            onClose();
+                        },
+                        (e) => {
+                            setIsLoading(false);
+                            toast.error(t('config.service.test_failed') + e.toString(), { style: toastStyle });
+                        }
+                    );
+                }}
+            >
                 <Toaster />
                 <div className='config-item'>
                     <h3 className='my-auto'>{t('services.help')}</h3>
@@ -54,6 +71,7 @@ export function Config(props) {
                             <Button variant='bordered'>{t(`services.translate.openai.${openaiConfig.service}`)}</Button>
                         </DropdownTrigger>
                         <DropdownMenu
+                            autoFocus='first'
                             aria-label='service'
                             onAction={(key) => {
                                 setOpenaiConfig({
@@ -68,7 +86,6 @@ export function Config(props) {
                     </Dropdown>
                 </div>
                 <div className='config-item'>
-                    <h3 className='my-auto'>{t('services.translate.openai.stream')}</h3>
                     <Switch
                         isSelected={openaiConfig['stream']}
                         onValueChange={(value) => {
@@ -77,14 +94,24 @@ export function Config(props) {
                                 stream: value,
                             });
                         }}
-                    />
+                        classNames={{
+                            base: 'flex flex-row-reverse justify-between w-full max-w-full',
+                        }}
+                    >
+                        {t('services.translate.openai.stream')}
+                    </Switch>
                 </div>
                 <div className='config-item'>
-                    <h3 className='my-auto'>{t('services.translate.openai.request_path')}</h3>
                     <Input
+                        label={t('services.translate.openai.request_path')}
+                        labelPlacement='outside-left'
                         value={openaiConfig['requestPath']}
                         variant='bordered'
-                        className='max-w-[50%]'
+                        classNames={{
+                            base: 'justify-between',
+                            label: 'text-[length:--nextui-font-size-medium]',
+                            mainWrapper: 'max-w-[50%]',
+                        }}
                         onValueChange={(value) => {
                             setOpenaiConfig({
                                 ...openaiConfig,
@@ -93,13 +120,18 @@ export function Config(props) {
                         }}
                     />
                 </div>
-                <div className='config-item '>
-                    <h3 className='my-auto'>{t('services.translate.openai.api_key')}</h3>
+                <div className='config-item'>
                     <Input
+                        label={t('services.translate.openai.api_key')}
+                        labelPlacement='outside-left'
                         type='password'
                         value={openaiConfig['apiKey']}
                         variant='bordered'
-                        className='max-w-[50%]'
+                        classNames={{
+                            base: 'justify-between',
+                            label: 'text-[length:--nextui-font-size-medium]',
+                            mainWrapper: 'max-w-[50%]',
+                        }}
                         onValueChange={(value) => {
                             setOpenaiConfig({
                                 ...openaiConfig,
@@ -115,6 +147,7 @@ export function Config(props) {
                             <Button variant='bordered'>{openaiConfig.model}</Button>
                         </DropdownTrigger>
                         <DropdownMenu
+                            autoFocus='first'
                             aria-label='service'
                             onAction={(key) => {
                                 setOpenaiConfig({
@@ -130,7 +163,7 @@ export function Config(props) {
                         </DropdownMenu>
                     </Dropdown>
                 </div>
-                <div className='config-item '>
+                <div className='config-item'>
                     <Textarea
                         label={t('services.translate.openai.system_prompt')}
                         labelPlacement='outside'
@@ -145,7 +178,7 @@ export function Config(props) {
                         }}
                     />
                 </div>
-                <div className='config-item '>
+                <div className='config-item'>
                     <Textarea
                         label={t('services.translate.openai.user_prompt')}
                         className='mb-3'
@@ -162,31 +195,15 @@ export function Config(props) {
                         }}
                     />
                 </div>
-                <div>
-                    <Button
-                        isLoading={isLoading}
-                        fullWidth
-                        color='primary'
-                        onPress={() => {
-                            setIsLoading(true);
-                            translate('hello', Language.auto, Language.zh_cn, { config: openaiConfig }).then(
-                                () => {
-                                    setIsLoading(false);
-                                    setOpenaiConfig(openaiConfig, true);
-                                    updateServiceList('openai_summary');
-                                    onClose();
-                                },
-                                (e) => {
-                                    setIsLoading(false);
-                                    toast.error(t('config.service.test_failed') + e.toString(), { style: toastStyle });
-                                }
-                            );
-                        }}
-                    >
-                        {t('common.save')}
-                    </Button>
-                </div>
-            </>
+                <Button
+                    type='submit'
+                    isLoading={isLoading}
+                    fullWidth
+                    color='primary'
+                >
+                    {t('common.save')}
+                </Button>
+            </form>
         )
     );
 }

--- a/src/services/translate/tencent/Config.jsx
+++ b/src/services/translate/tencent/Config.jsx
@@ -26,7 +26,24 @@ export function Config(props) {
 
     return (
         config !== null && (
-            <>
+            <form
+                onSubmit={(e) => {
+                    e.preventDefault();
+                    setIsLoading(true);
+                    translate('hello', Language.auto, Language.zh_cn, { config }).then(
+                        () => {
+                            setIsLoading(false);
+                            setConfig(config, true);
+                            updateServiceList('tencent');
+                            onClose();
+                        },
+                        (e) => {
+                            setIsLoading(false);
+                            toast.error(t('config.service.test_failed') + e.toString(), { style: toastStyle });
+                        }
+                    );
+                }}
+            >
                 <Toaster />
                 <div className={'config-item'}>
                     <h3 className='my-auto'>{t('services.help')}</h3>
@@ -39,11 +56,16 @@ export function Config(props) {
                     </Button>
                 </div>
                 <div className={'config-item'}>
-                    <h3 className='my-auto'>{t('services.translate.tencent.secret_id')}</h3>
                     <Input
+                        label={t('services.translate.tencent.secret_id')}
+                        labelPlacement='outside-left'
                         value={config['secret_id']}
                         variant='bordered'
-                        className='max-w-[50%]'
+                        classNames={{
+                            base: 'justify-between',
+                            label: 'text-[length:--nextui-font-size-medium]',
+                            mainWrapper: 'max-w-[50%]',
+                        }}
                         onValueChange={(value) => {
                             setConfig({
                                 ...config,
@@ -53,11 +75,16 @@ export function Config(props) {
                     />
                 </div>
                 <div className={'config-item'}>
-                    <h3 className='my-auto'>{t('services.translate.tencent.secret_key')}</h3>
                     <Input
+                        label={t('services.translate.tencent.secret_key')}
+                        labelPlacement='outside-left'
                         value={config['secret_key']}
                         variant='bordered'
-                        className='max-w-[50%]'
+                        classNames={{
+                            base: 'justify-between',
+                            label: 'text-[length:--nextui-font-size-medium]',
+                            mainWrapper: 'max-w-[50%]',
+                        }}
                         onValueChange={(value) => {
                             setConfig({
                                 ...config,
@@ -66,31 +93,15 @@ export function Config(props) {
                         }}
                     />
                 </div>
-                <div>
-                    <Button
-                        isLoading={isLoading}
-                        color='primary'
-                        fullWidth
-                        onPress={() => {
-                            setIsLoading(true);
-                            translate('hello', Language.auto, Language.zh_cn, { config }).then(
-                                () => {
-                                    setIsLoading(false);
-                                    setConfig(config, true);
-                                    updateServiceList('tencent');
-                                    onClose();
-                                },
-                                (e) => {
-                                    setIsLoading(false);
-                                    toast.error(t('config.service.test_failed') + e.toString(), { style: toastStyle });
-                                }
-                            );
-                        }}
-                    >
-                        {t('common.save')}
-                    </Button>
-                </div>
-            </>
+                <Button
+                    type='submit'
+                    isLoading={isLoading}
+                    color='primary'
+                    fullWidth
+                >
+                    {t('common.save')}
+                </Button>
+            </form>
         )
     );
 }

--- a/src/services/translate/transmart/Config.jsx
+++ b/src/services/translate/transmart/Config.jsx
@@ -26,7 +26,24 @@ export function Config(props) {
 
     return (
         config !== null && (
-            <>
+            <form
+                onSubmit={(e) => {
+                    e.preventDefault();
+                    setIsLoading(true);
+                    translate('hello', Language.auto, Language.zh_cn, { config }).then(
+                        () => {
+                            setIsLoading(false);
+                            setConfig(config, true);
+                            updateServiceList('transmart');
+                            onClose();
+                        },
+                        (e) => {
+                            setIsLoading(false);
+                            toast.error(t('config.service.test_failed') + e.toString(), { style: toastStyle });
+                        }
+                    );
+                }}
+            >
                 <Toaster />
                 <div className={'config-item'}>
                     <h3 className='my-auto'>{t('services.help')}</h3>
@@ -39,11 +56,16 @@ export function Config(props) {
                     </Button>
                 </div>
                 <div className={'config-item'}>
-                    <h3 className='my-auto'>{t('services.translate.transmart.username')}</h3>
                     <Input
+                        label={t('services.translate.transmart.username')}
+                        labelPlacement='outside-left'
                         value={config['username']}
                         variant='bordered'
-                        className='max-w-[50%]'
+                        classNames={{
+                            base: 'justify-between',
+                            label: 'text-[length:--nextui-font-size-medium]',
+                            mainWrapper: 'max-w-[50%]',
+                        }}
                         onValueChange={(value) => {
                             setConfig({
                                 ...config,
@@ -53,11 +75,16 @@ export function Config(props) {
                     />
                 </div>
                 <div className={'config-item'}>
-                    <h3 className='my-auto'>{t('services.translate.transmart.token')}</h3>
                     <Input
+                        label={t('services.translate.transmart.token')}
+                        labelPlacement='outside-left'
                         value={config['token']}
                         variant='bordered'
-                        className='max-w-[50%]'
+                        classNames={{
+                            base: 'justify-between',
+                            label: 'text-[length:--nextui-font-size-medium]',
+                            mainWrapper: 'max-w-[50%]',
+                        }}
                         onValueChange={(value) => {
                             setConfig({
                                 ...config,
@@ -66,31 +93,15 @@ export function Config(props) {
                         }}
                     />
                 </div>
-                <div>
-                    <Button
-                        isLoading={isLoading}
-                        color='primary'
-                        fullWidth
-                        onPress={() => {
-                            setIsLoading(true);
-                            translate('hello', Language.auto, Language.zh_cn, { config }).then(
-                                () => {
-                                    setIsLoading(false);
-                                    setConfig(config, true);
-                                    updateServiceList('transmart');
-                                    onClose();
-                                },
-                                (e) => {
-                                    setIsLoading(false);
-                                    toast.error(t('config.service.test_failed') + e.toString(), { style: toastStyle });
-                                }
-                            );
-                        }}
-                    >
-                        {t('common.save')}
-                    </Button>
-                </div>
-            </>
+                <Button
+                    type='submit'
+                    isLoading={isLoading}
+                    color='primary'
+                    fullWidth
+                >
+                    {t('common.save')}
+                </Button>
+            </form>
         )
     );
 }

--- a/src/services/translate/volcengine/Config.jsx
+++ b/src/services/translate/volcengine/Config.jsx
@@ -26,7 +26,24 @@ export function Config(props) {
 
     return (
         config !== null && (
-            <>
+            <form
+                onSubmit={(e) => {
+                    e.preventDefault();
+                    setIsLoading(true);
+                    translate('hello', Language.auto, Language.zh_cn, { config }).then(
+                        (v) => {
+                            setIsLoading(false);
+                            setConfig(config, true);
+                            updateServiceList('volcengine');
+                            onClose();
+                        },
+                        (e) => {
+                            setIsLoading(false);
+                            toast.error(t('config.service.test_failed') + e.toString(), { style: toastStyle });
+                        }
+                    );
+                }}
+            >
                 <Toaster />
                 <div className={'config-item'}>
                     <h3 className='my-auto'>{t('services.help')}</h3>
@@ -39,11 +56,16 @@ export function Config(props) {
                     </Button>
                 </div>
                 <div className={'config-item'}>
-                    <h3 className='my-auto'>{t('services.translate.volcengine.appid')}</h3>
                     <Input
+                        label={t('services.translate.volcengine.appid')}
+                        labelPlacement='outside-left'
                         value={config['appid']}
                         variant='bordered'
-                        className='max-w-[50%]'
+                        classNames={{
+                            base: 'justify-between',
+                            label: 'text-[length:--nextui-font-size-medium]',
+                            mainWrapper: 'max-w-[50%]',
+                        }}
                         onValueChange={(value) => {
                             setConfig({
                                 ...config,
@@ -53,11 +75,16 @@ export function Config(props) {
                     />
                 </div>
                 <div className={'config-item'}>
-                    <h3 className='my-auto'>{t('services.translate.volcengine.secret')}</h3>
                     <Input
+                        label={t('services.translate.volcengine.secret')}
+                        labelPlacement='outside-left'
                         value={config['secret']}
                         variant='bordered'
-                        className='max-w-[50%]'
+                        classNames={{
+                            base: 'justify-between',
+                            label: 'text-[length:--nextui-font-size-medium]',
+                            mainWrapper: 'max-w-[50%]',
+                        }}
                         onValueChange={(value) => {
                             setConfig({
                                 ...config,
@@ -66,31 +93,15 @@ export function Config(props) {
                         }}
                     />
                 </div>
-                <div>
-                    <Button
-                        isLoading={isLoading}
-                        color='primary'
-                        fullWidth
-                        onPress={() => {
-                            setIsLoading(true);
-                            translate('hello', Language.auto, Language.zh_cn, { config }).then(
-                                (v) => {
-                                    setIsLoading(false);
-                                    setConfig(config, true);
-                                    updateServiceList('volcengine');
-                                    onClose();
-                                },
-                                (e) => {
-                                    setIsLoading(false);
-                                    toast.error(t('config.service.test_failed') + e.toString(), { style: toastStyle });
-                                }
-                            );
-                        }}
-                    >
-                        {t('common.save')}
-                    </Button>
-                </div>
-            </>
+                <Button
+                    type='submit'
+                    isLoading={isLoading}
+                    color='primary'
+                    fullWidth
+                >
+                    {t('common.save')}
+                </Button>
+            </form>
         )
     );
 }

--- a/src/services/translate/youdao/Config.jsx
+++ b/src/services/translate/youdao/Config.jsx
@@ -26,7 +26,24 @@ export function Config(props) {
 
     return (
         config !== null && (
-            <>
+            <form
+                onSubmit={(e) => {
+                    e.preventDefault();
+                    setIsLoading(true);
+                    translate('hello', Language.auto, Language.zh_cn, { config }).then(
+                        () => {
+                            setIsLoading(false);
+                            setConfig(config, true);
+                            updateServiceList('youdao');
+                            onClose();
+                        },
+                        (e) => {
+                            setIsLoading(false);
+                            toast.error(t('config.service.test_failed') + e.toString(), { style: toastStyle });
+                        }
+                    );
+                }}
+            >
                 <Toaster />
                 <div className={'config-item'}>
                     <h3 className='my-auto'>{t('services.help')}</h3>
@@ -39,11 +56,16 @@ export function Config(props) {
                     </Button>
                 </div>
                 <div className={'config-item'}>
-                    <h3 className='my-auto'>{t('services.translate.youdao.appkey')}</h3>
                     <Input
+                        label={t('services.translate.youdao.appkey')}
+                        labelPlacement='outside-left'
                         value={config['appkey']}
                         variant='bordered'
-                        className='max-w-[50%]'
+                        classNames={{
+                            base: 'justify-between',
+                            label: 'text-[length:--nextui-font-size-medium]',
+                            mainWrapper: 'max-w-[50%]',
+                        }}
                         onValueChange={(value) => {
                             setConfig({
                                 ...config,
@@ -53,11 +75,16 @@ export function Config(props) {
                     />
                 </div>
                 <div className={'config-item'}>
-                    <h3 className='my-auto'>{t('services.translate.youdao.key')}</h3>
                     <Input
+                        label={t('services.translate.youdao.key')}
+                        labelPlacement='outside-left'
                         value={config['key']}
                         variant='bordered'
-                        className='max-w-[50%]'
+                        classNames={{
+                            base: 'justify-between',
+                            label: 'text-[length:--nextui-font-size-medium]',
+                            mainWrapper: 'max-w-[50%]',
+                        }}
                         onValueChange={(value) => {
                             setConfig({
                                 ...config,
@@ -66,31 +93,15 @@ export function Config(props) {
                         }}
                     />
                 </div>
-                <div>
-                    <Button
-                        isLoading={isLoading}
-                        color='primary'
-                        fullWidth
-                        onPress={() => {
-                            setIsLoading(true);
-                            translate('hello', Language.auto, Language.zh_cn, { config }).then(
-                                () => {
-                                    setIsLoading(false);
-                                    setConfig(config, true);
-                                    updateServiceList('youdao');
-                                    onClose();
-                                },
-                                (e) => {
-                                    setIsLoading(false);
-                                    toast.error(t('config.service.test_failed') + e.toString(), { style: toastStyle });
-                                }
-                            );
-                        }}
-                    >
-                        {t('common.save')}
-                    </Button>
-                </div>
-            </>
+                <Button
+                    type='submit'
+                    isLoading={isLoading}
+                    color='primary'
+                    fullWidth
+                >
+                    {t('common.save')}
+                </Button>
+            </form>
         )
     );
 }


### PR DESCRIPTION
Following #457, this PR refactored the config modal component in translate pages, besides using the 'form' element and adding a label for the 'Input' component, I also added a label for the 'Switch' component and added 'autoFocus' prop for 'Dropdown' to enable auto-focus the first option after opening the dropdown menu.