### PR TITLE
docs: Add warning about new version of Webkit2Gtk

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,10 @@ brew upgrade --cask pot
 
 ### Arch/Manjaro
 
+> [!WARNING]  
+> 在最新版本的 [Webkit2Gtk](https://archlinux.org/packages/extra/x86_64/webkit2gtk) (2.42.0) 中，由于nVidia专有驱动未完全实现DMABUF，将导致无法启动和崩溃的情况发生。<br>
+> 请降级或在 `/etc/environment` （或者其他设置环境变量的地方）中加入 `WEBKIT_DISABLE_DMABUF_RENDERER=1` 环境变量关闭DMABUF的使用。
+
 1. 在 [AUR](https://aur.archlinux.org/packages?O=0&K=pot-translation) 查看
 
 使用 `AUR helper` 安装：

--- a/README_EN.md
+++ b/README_EN.md
@@ -211,6 +211,10 @@ Please note that: There are two deb package, `universal` is based on `glibc2.28`
 
 ### Arch/Manjaro
 
+> [!WARNING]  
+> In newer version of [Webkit2Gtk](https://archlinux.org/packages/extra/x86_64/webkit2gtk) (2.42.0), Because nVidia Proprietary drives are not fully implemented DMABUF, it will cause failure to start and crash.<br>
+> Please downgrade or add the `WEBKIT_DISABLE_DMABUF_RENDERER=1` environment variable to `/etc/environment` (or other places where environment variables are set) to turn off the use of DMABUF.
+
 1. View on [AUR](https://aur.archlinux.org/packages?O=0&K=pot-translation)
 
 Use aur helper：


### PR DESCRIPTION
linux 新版本 Webkit2Gtk 会导致程序崩溃，并且是nvidia驱动的问题，加个提示