### PR TITLE
feat: support default collapse

### DIFF
--- a/src/window/Config/pages/Service/Translate/ServiceItem/index.jsx
+++ b/src/window/Config/pages/Service/Translate/ServiceItem/index.jsx
@@ -2,7 +2,7 @@ import { RxDragHandleHorizontal } from 'react-icons/rx';
 import { Spacer, Button, Switch } from '@nextui-org/react';
 import { MdDeleteOutline } from 'react-icons/md';
 import { useTranslation } from 'react-i18next';
-import { BiSolidEdit } from 'react-icons/bi';
+import { BiSolidEdit, BiCollapseVertical, BiExpandVertical } from 'react-icons/bi';
 import React from 'react';
 
 import * as builtinServices from '../../../../../../services/translate';
@@ -59,6 +59,23 @@ export default function ServiceItem(props) {
                             setServiceConfig({ ...serviceConfig, enable: v });
                         }}
                     />
+                    <Spacer x={2} />
+                    <Button
+                        isIconOnly
+                        size='sm'
+                        variant='light'
+                        onPress={() => {
+                            const collapse = serviceConfig['collapse'] ?? false;
+                            setServiceConfig({ ...serviceConfig, collapse: !collapse });
+                        }}
+                    >
+                        {serviceConfig['collapse'] ? (
+                            <BiExpandVertical className='text-2xl' />
+                        ) : (
+                            <BiCollapseVertical className='text-2xl' />
+                        )}
+                    </Button>
+                    <Spacer x={2} />
                     <Button
                         isIconOnly
                         size='sm'

--- a/src/window/Translate/index.jsx
+++ b/src/window/Translate/index.jsx
@@ -273,6 +273,7 @@ export default function Translate() {
                                             translateServiceList.map((service, index) => {
                                                 const config = serviceConfig[service] ?? {};
                                                 const enable = config['enable'] ?? true;
+                                                const collapse = config['collapse'];
 
                                                 return enable ? (
                                                     <Draggable
@@ -291,6 +292,7 @@ export default function Translate() {
                                                                     name={service}
                                                                     index={index}
                                                                     translateServiceList={translateServiceList}
+                                                                    defaultCollapse={collapse}
                                                                 />
                                                                 <Spacer y={2} />
                                                             </div>


### PR DESCRIPTION
调用OpenAI等服务的接口需要收费，有时进行一些简单的翻译时不需要使用这些服务，因此添加了“默认折叠”功能，逻辑为：

可在服务设置中针对某一服务设置默认展开还是默认折叠：

![2024-03-12-19 38 13@2x](https://github.com/pot-app/pot-desktop/assets/20661574/7ffef6f7-fd09-4574-836b-7d1f1ccac754)

进行翻译时，默认折叠的服务不会主动进行翻译：

![2024-03-12-19 39 49@2x](https://github.com/pot-app/pot-desktop/assets/20661574/3c7d77be-32f0-4b43-b516-96dac093dbcf)

只有手动将其展开时才会进行翻译：

![2024-03-12-19 40 53@2x](https://github.com/pot-app/pot-desktop/assets/20661574/d4ac868d-51d7-4210-9c0d-2f8845377742)

此时：
- 当翻译窗口未关闭时，将某一服务手动展开后，在后续翻译过程中该服务将会保持为展开状态，开始主动进行翻译；反之亦然；
- 当翻译窗口关闭后，下次再打开时，设置为默认折叠的服务依然会默认折叠；

P.S. 这是个很棒的项目，感谢作者🙏 一个小建议：代码中import路径太长了：

```js
import * as builtinCollectionServices from '../../../../services/collection';
```

可以考虑在`vite.config.js`中设置`resolve.alias`：

```js
export default defineConfig(async () => ({
   // ...
    resolve: {
        alias: {
            '@': resolve(__dirname, 'src'),
        }
    }
}));
```