### PR TITLE
feat: improve screenshot speed

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "const-random",
@@ -7237,18 +7237,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.26"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97e415490559a91254a2979b4829267a57d2fcd741a98eee8b722fb57289aa0"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.26"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd7e48ccf166952882ca8bd778a43502c64f33bf94c12ebe2a7f08e5a0f6689f"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src-tauri/src/window.rs
+++ b/src-tauri/src/window.rs
@@ -1,12 +1,10 @@
-use crate::config::get;
-use crate::config::set;
-use crate::StringWrapper;
-use crate::APP;
+use crate::{
+    config::{get, set},
+    screenshot, StringWrapper, APP,
+};
 use log::{info, warn};
-use tauri::Manager;
-use tauri::Monitor;
-use tauri::Window;
-use tauri::WindowBuilder;
+use mouse_position::mouse_position::{Mouse, Position};
+use tauri::{Manager, Monitor, Window, WindowBuilder};
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 use window_shadows::set_shadow;
 
@@ -56,8 +54,6 @@ fn get_current_monitor(x: i32, y: i32) -> Monitor {
 
 // Creating a window on the mouse monitor
 fn build_window(label: &str, title: &str) -> (Window, bool) {
-    use mouse_position::mouse_position::{Mouse, Position};
-
     let mouse_position = match Mouse::get_mouse_position() {
         Mouse::Position { x, y } => Position { x, y },
         Mouse::Error => {
@@ -120,7 +116,6 @@ pub fn config_window() {
 }
 
 fn translate_window() -> Window {
-    use mouse_position::mouse_position::{Mouse, Position};
     // Mouse physical position
     let mut mouse_position = match Mouse::get_mouse_position() {
         Mouse::Position { x, y } => Position { x, y },
@@ -337,6 +332,17 @@ pub fn ocr_recognize() {
     });
 }
 pub fn ocr_translate() {
+    let mouse_position = match Mouse::get_mouse_position() {
+        Mouse::Position { x, y } => Position { x, y },
+        Mouse::Error => {
+            warn!("Mouse position not found, using (0, 0) as default");
+            Position { x: 0, y: 0 }
+        }
+    };
+    let current_monitor = get_current_monitor(mouse_position.x, mouse_position.y);
+    let position = current_monitor.position();
+    screenshot(position.x, position.y);
+
     let window = screenshot_window();
     let window_ = window.clone();
     window.listen("success", move |event| {

--- a/src/window/Screenshot/index.jsx
+++ b/src/window/Screenshot/index.jsx
@@ -19,14 +19,9 @@ export default function Screenshot() {
     const imgRef = useRef();
 
     useEffect(() => {
-        currentMonitor().then((monitor) => {
-            const position = monitor.position;
-            invoke('screenshot', { x: position.x, y: position.y }).then(() => {
-                appCacheDir().then((appCacheDirPath) => {
-                    join(appCacheDirPath, 'pot_screenshot.png').then((filePath) => {
-                        setImgurl(convertFileSrc(filePath));
-                    });
-                });
+        appCacheDir().then((appCacheDirPath) => {
+            join(appCacheDirPath, 'pot_screenshot.png').then((filePath) => {
+                setImgurl(convertFileSrc(filePath));
             });
         });
     }, []);


### PR DESCRIPTION
fix #760 

调整截图调用链以优化截图速度

``` log
[2024-03-23][23:29:17][INFO][pot::window] mouse_position: 6µs
[2024-03-23][23:29:17][INFO][pot::window] Mouse position: 875, 640
[2024-03-23][23:29:17][INFO][pot::window] Current Monitor: Monitor { name: Some("\\\\.\\DISPLAY1"), size: PhysicalSize { width: 2560, height: 1600 }, position: PhysicalPosition { x: 0, y: 0 }, scale_factor: 1.5 }
[2024-03-23][23:29:17][INFO][pot::window] current_monitor: 150.9µs
[2024-03-23][23:29:17][INFO][pot::window] position: 155.7µs
[2024-03-23][23:29:17][INFO][pot::screenshot] Screenshot screen with position: x=0, y=0, 0ns
[2024-03-23][23:29:17][INFO][pot::screenshot] Screen: DisplayInfo { id: 2776250164, x: 0, y: 0, width: 2560, height: 1600, rotation: 0.0, scale_factor: 1.0, is_primary: true }, 130.6µs
[2024-03-23][23:29:17][INFO][pot::screenshot] APP: 139.8µs
[2024-03-23][23:29:17][INFO][pot::screenshot] cache_dir: 154.5µs
[2024-03-23][23:29:17][INFO][pot::screenshot] bundle.identifier: 159.8µs
[2024-03-23][23:29:17][INFO][pot::screenshot] capture screen: 90.4274ms
[2024-03-23][23:29:17][INFO][pot::screenshot] to_png: 98.6395ms
[2024-03-23][23:29:17][INFO][pot::window] screenshot: 101.6898ms
[2024-03-23][23:29:17][INFO][pot::window] Mouse position: 875, 640
[2024-03-23][23:29:17][INFO][pot::window] Current Monitor: Monitor { name: Some("\\\\.\\DISPLAY1"), size: PhysicalSize { width: 2560, height: 1600 }, position: PhysicalPosition { x: 0, y: 0 }, scale_factor: 1.5 }
[2024-03-23][23:29:17][INFO][pot::window] Window not existence, Creating new window: screenshot
[2024-03-23][23:29:18][INFO][pot::window] screenshot1: 266.825ms
[2024-03-23][23:29:18][INFO][pot::window] loaded1: 379.0019ms
[2024-03-23][23:29:18][TRACE][os_info::imp] windows::current_platform is called
[2024-03-23][23:29:18][TRACE][os_info::imp] Returning Info { os_type: Windows, version: Semantic(10, 0, 22631), edition: Some("Windows 11 Professional"), codename: None, bitness: X64, architecture: None }
[2024-03-23][23:29:18][INFO][pot::window] loaded2: 1.0575282s
```

优化后，截图+窗口加载时间可以控制在300ms以内，截图正式展示到界面上需要1秒左右
测量版本为rust release+production js版本

日志中，`loaded1`为截图页js iife执行时emit的事件产生的记录，`loaded2`为useEffect执行时emit的事件产生的记录

可见js初始化时间占据了不少时间，此pr暂不对这一部分进行优化