### PR TITLE
设置划词翻译默认选中所有文本 并解决过程中发现的bug

### DIFF
--- a/src/window/Translate/components/SourceArea/index.jsx
+++ b/src/window/Translate/components/SourceArea/index.jsx
@@ -45,6 +45,8 @@ export default function SourceArea(props) {
     const { t } = useTranslation();
     const textAreaRef = useRef();
     const speak = useVoice();
+    // 是否是首次打开页面 首次打开页面时全选内容 这样可以将'划词翻译'和'输入翻译'合并为一个功能
+    const [first, setFirst] = useState(false);
 
     const handleNewText = async (text) => {
         text = text.trim();
@@ -151,6 +153,7 @@ export default function SourceArea(props) {
                 syncSourceText();
             });
         }
+        setFirst(true);
     };
 
     const keyDown = (event) => {
@@ -239,6 +242,9 @@ export default function SourceArea(props) {
         textAreaRef.current.style.height = '50px';
         textAreaRef.current.style.height = textAreaRef.current.scrollHeight + 'px';
     }, [sourceText]);
+    useEffect(() => {
+        textAreaRef.current.select();
+    }, [first]);
 
     const detect_language = async (text) => {
         setDetectLanguage(await detect(text));


### PR DESCRIPTION
resolve #681 

默认选中可以使得划词翻译和输入翻译采用同一个功能入口
优点:日常使用只需要一个快捷键,减小用户心智负担
缺点:会多一次无效的查询,如果是收费api可能会造成费用上升
是否有必要添加功能开关?