### PR TITLE
feature: var name transform

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -101,7 +101,7 @@ fn main() {
             }
             match get("proxy_enable") {
                 Some(v) => {
-                    if v.as_bool().unwrap() {
+                    if v.as_bool().unwrap() && get("proxy_host").map_or(false, |host| !host.as_str().unwrap().is_empty()) {
                         let _ = set_proxy();
                     }
                 }


### PR DESCRIPTION
## Purpose
Make SourceArea support switching between multiple variable styles, It is usually useful in programming scenarios.

## Guide
This feature is triggered by selecting text in the SourceArea and using the keyboard combination <kbd>alt</kbd>+<kbd>shift</kbd>+<kbd>U</kbd>.
As a preview feature, the keyboard combination does not support customization.

## Demo
![transform varName](https://github.com/user-attachments/assets/9c628792-da4c-4e98-9bc1-6f9c5982b96d)

resolve #930
