### PR TITLE
chore: update OpenAI non-streaming request method

### DIFF
--- a/src/services/translate/openai/index.jsx
+++ b/src/services/translate/openai/index.jsx
@@ -118,13 +118,13 @@ export async function translate(text, from, to, options) {
             throw `Http Request Error\nHttp Status: ${res.status}\n${JSON.stringify(res.data)}`;
         }
     } else {
-        let res = await fetch(apiUrl.href, {
+        let res = await window.fetch(apiUrl.href, {
             method: 'POST',
             headers: headers,
-            body: Body.json(body),
+            body: JSON.stringify(body),
         });
         if (res.ok) {
-            let result = res.data;
+            let result = await res.json();
             const { choices } = result;
             if (choices) {
                 let target = choices[0].message.content.trim();
@@ -143,7 +143,8 @@ export async function translate(text, from, to, options) {
                 throw JSON.stringify(result);
             }
         } else {
-            throw `Http Request Error\nHttp Status: ${res.status}\n${JSON.stringify(res.data)}`;
+            const errorData = await res.json().catch(() => null);
+            throw `Http Request Error\nHttp Status: ${res.status}\n${errorData ? JSON.stringify(errorData) : 'No error details available'}`;
         }
     }
 }


### PR DESCRIPTION
OpenAI翻译时非流式的http请求方式和流式的请求方式保持一致，解决win上host后面带端口号报错的问题 https://github.com/pot-app/pot-desktop/issues/999