### PR TITLE
fix(window): Refactor window size and position to use LogicalSize and LogicalPosition

### DIFF
--- a/src-tauri/src/window.rs
+++ b/src-tauri/src/window.rs
@@ -154,9 +154,9 @@ fn translate_window() -> Window {
     let dpi = monitor.scale_factor();
 
     window
-        .set_size(tauri::PhysicalSize::new(
-            (width as f64) * dpi,
-            (height as f64) * dpi,
+        .set_size(tauri::LogicalSize::new(
+            width as f64,
+            height as f64,
         ))
         .unwrap();
 
@@ -209,9 +209,9 @@ fn translate_window() -> Window {
                 None => 0,
             };
             window
-                .set_position(tauri::PhysicalPosition::new(
-                    (position_x as f64) * dpi,
-                    (position_y as f64) * dpi,
+                .set_position(tauri::LogicalPosition::new(
+                    position_x as f64,
+                    position_y as f64,
                 ))
                 .unwrap();
         }
@@ -297,12 +297,10 @@ pub fn recognize_window() {
             400
         }
     };
-    let monitor = window.current_monitor().unwrap().unwrap();
-    let dpi = monitor.scale_factor();
     window
-        .set_size(tauri::PhysicalSize::new(
-            (width as f64) * dpi,
-            (height as f64) * dpi,
+        .set_size(tauri::LogicalSize::new(
+            width as f64,
+            height as f64,
         ))
         .unwrap();
     window.center().unwrap();


### PR DESCRIPTION
**TLDR:** This commit ensures that Pot has the same size on monitors with different scale ratios. It no longer becomes progressively smaller on non-primary monitors with smaller scale ratios.

---

This commit refactors the window size and position calculations in `src-tauri/src/window.rs` to use `LogicalSize` and `LogicalPosition` instead of `PhysicalSize` and `PhysicalPosition`. 

This change ensures that the window size and position are independent of the screen's DPI, leading to a more consistent user experience across different displays. The DPI scaling is now handled internally by Tauri.

Fix #962 