### PR TITLE
Add translation modes and update UI for translation settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+package-lock.json
+.gitignore

--- a/src/i18n/locales/en_US.json
+++ b/src/i18n/locales/en_US.json
@@ -458,7 +458,14 @@
             "copy": "Copy",
             "retry": "Try again",
             "delete_newline": "Delete Newline",
-            "translate_back": "Translation back to the original"
+            "translate_back": "Translation back to the original",
+            "mode": {
+                "normal": "Normal Mode (Translate each time)",
+                "remember_collapse": "Remember Collapse State",
+                "always_collapse": "Always Collapse",
+                "quit": "Disable This Service",
+                "disabled_success": "has been disabled"
+            }
         },
         "recognize": {
             "recognize": "Recognize",

--- a/src/i18n/locales/zh_CN.json
+++ b/src/i18n/locales/zh_CN.json
@@ -458,7 +458,14 @@
             "copy": "复制",
             "retry": "重试",
             "delete_newline": "删除换行",
-            "translate_back": "翻译回原文"
+            "translate_back": "翻译回原文",
+            "mode": {
+                "normal": "正常模式（每次都翻译）",
+                "remember_collapse": "记住折叠状态",
+                "always_collapse": "总是折叠",
+                "quit": "禁用此服务",
+                "disabled_success": "已被禁用"
+            }
         },
         "recognize": {
             "recognize": "重新识别",

--- a/src/window/Translate/index.jsx
+++ b/src/window/Translate/index.jsx
@@ -228,6 +228,8 @@ export default function Translate() {
         collectionServiceInstanceList,
     ]);
 
+
+
     return (
         pluginList && (
             <div
@@ -261,18 +263,20 @@ export default function Translate() {
                     >
                         <BsPinFill className={`text-[20px] ${pined ? 'text-primary' : 'text-default-400'}`} />
                     </Button>
-                    <Button
-                        isIconOnly
-                        size='sm'
-                        variant='flat'
-                        disableAnimation
-                        className={`my-auto ${osType === 'Darwin' && 'hidden'} bg-transparent`}
-                        onPress={() => {
-                            void appWindow.close();
-                        }}
-                    >
-                        <AiFillCloseCircle className='text-[20px] text-default-400' />
-                    </Button>
+                    {osType !== 'Darwin' && (
+                        <Button
+                            isIconOnly
+                            size='sm'
+                            variant='flat'
+                            disableAnimation
+                            className='my-auto bg-transparent'
+                            onPress={() => {
+                                void appWindow.close();
+                            }}
+                        >
+                            <AiFillCloseCircle className='text-[20px] text-default-400' />
+                        </Button>
+                    )}
                 </div>
                 <div className={`${osType === 'Linux' ? 'h-[calc(100vh-37px)]' : 'h-[calc(100vh-35px)]'} px-[8px]`}>
                     <div className='h-full overflow-y-auto'>


### PR DESCRIPTION
- Introduced new translation modes: Normal, Remember Collapse State, Always Collapse, and Quit.
- Updated the UI to allow users to select translation modes via a dropdown menu.
- Enhanced the logic for managing the visibility of the translation area based on the selected mode.
- Updated English and Chinese localization files to include new translation mode strings.
- 
<img width="356" alt="image" src="https://github.com/user-attachments/assets/0ca77c56-9e67-47df-a51d-6b028e2153b7" />
