### PR TITLE
Style anki text with HTML tag

### DIFF
--- a/src/services/collection/anki/index.jsx
+++ b/src/services/collection/anki/index.jsx
@@ -22,16 +22,23 @@ export async function collection(source, target, options = {}) {
         let result = '';
         if (typeof target === 'object') {
             for (let explanation of target.explanations) {
-                result += explanation.trait + '. ';
-                let index = 0;
-                for (let explain of explanation.explains) {
-                    index++;
-                    if (index !== explanation.explains.length) {
-                        result += explain + '; ';
+                result += `<span class="explanation trait">${explanation.trait} </span>`;
+                for (let i = 0; i < explanation.explains.length; i++) {
+                    if (i === 0) {
+                        result += `<span class="explanation explain primary">${explanation.explains[i]}</span> `;
                     } else {
-                        result += explain + '<br>';
+                        result += `<span class="explanation explain secondary">${explanation.explains[i]}</span> `;
                     }
                 }
+                result += '<br>';
+            }
+
+            if (target.sentence) {
+                result += '<ul class="sentence">';
+                for (let sentence of target.sentence) {
+                    result += `<li><span class="sentence-source">${sentence.source}</span></li>`;
+                }
+                result += '</ul>';
             }
         } else {
             return target;


### PR DESCRIPTION
This PR adds HTML tags to the Anki text, so users can easily style their Anki cards by changing the `Styling` setting

## Comparison of the back of the Anki card

### Before

<img width="767" alt="image" src="https://github.com/user-attachments/assets/526147da-99a1-42fb-a00c-991af3c435d1" />

### After (with #1142 and my custom CSS style)

```cs
.card {
    font-family: arial;
    font-size: 20px;
    text-align: center;
    color: black;
    background-color: white;
}

.back {
  text-align: left;
}

.explanation.trait {
  color: #5d2fc1
}

.explanation.explain.primary {
  font-weight: 700;
  font-size: 18px;
  color: #1d2a57;
}

.explanation.explain.secondary {
  font-size: 16px;
  color: #0580e8;
}

.sentence {
  color: #1d2a57;
  font-size: 17px;
}
```

<img width="1208" alt="image" src="https://github.com/user-attachments/assets/6e51f3b2-0193-430b-bbc2-8fe78f61697f" />



