### PR TITLE
chore: use `rollup/wasm-node` to support loongarch64 and POWER8 build

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,5 +55,10 @@
         "tailwindcss": "^3.4.14",
         "typescript": "^5.6.3",
         "vite": "^5.4.10"
+    },
+    "pnpm": {
+        "overrides": {
+            "rollup": "npm:@rollup/wasm-node"
+        }
     }
 }


### PR DESCRIPTION
`rollup` does not ship binaries for LoongArch64 or Power8. Use `rollup/wasm-node` as a replacement.