### PR TITLE
fix(hotkey): make registration robust and persist only on success

### DIFF
--- a/src-tauri/src/hotkey.rs
+++ b/src-tauri/src/hotkey.rs
@@ -4,23 +4,36 @@ use crate::APP;
 use log::{info, warn};
 use tauri::{AppHandle, GlobalShortcutManager};
 
+fn get_hotkey_from_store(name: &str) -> String {
+    match get(name) {
+        Some(v) => v.as_str().unwrap_or_default().to_string(),
+        None => {
+            set(name, "");
+            String::new()
+        }
+    }
+}
+
 fn register<F>(app_handle: &AppHandle, name: &str, handler: F, key: &str) -> Result<(), String>
 where
     F: Fn() + Send + 'static,
 {
-    let hotkey = {
-        if key.is_empty() {
-            match get(name) {
-                Some(v) => v.as_str().unwrap().to_string(),
-                None => {
-                    set(name, "");
-                    String::new()
-                }
-            }
-        } else {
-            key.to_string()
-        }
+    let hotkey = if key.is_empty() {
+        get_hotkey_from_store(name)
+    } else {
+        key.to_string()
     };
+
+    let old_hotkey = get_hotkey_from_store(name);
+    if !old_hotkey.is_empty() {
+        // Always try to unregister old key first to avoid depending on frontend order.
+        if let Err(e) = app_handle.global_shortcut_manager().unregister(&old_hotkey) {
+            warn!(
+                "Failed to unregister old shortcut: {} for {} {:?}",
+                old_hotkey, name, e
+            );
+        }
+    }
 
     if !hotkey.is_empty() {
         match app_handle
@@ -35,7 +48,12 @@ where
                 return Err(e.to_string());
             }
         };
+    } else {
+        info!("Cleared global shortcut for {}", name);
     }
+
+    // Persist only when backend registration flow succeeds.
+    set(name, hotkey);
     Ok(())
 }
 
@@ -43,27 +61,42 @@ where
 pub fn register_shortcut(shortcut: &str) -> Result<(), String> {
     let app_handle = APP.get().unwrap();
     match shortcut {
-        "hotkey_selection_translate" => register(
-            app_handle,
-            "hotkey_selection_translate",
-            selection_translate,
-            "",
-        )?,
+        "hotkey_selection_translate" => {
+            register(app_handle, "hotkey_selection_translate", selection_translate, "")?
+        }
         "hotkey_input_translate" => {
             register(app_handle, "hotkey_input_translate", input_translate, "")?
         }
-        "hotkey_ocr_recognize" => register(app_handle, "hotkey_ocr_recognize", ocr_recognize, "")?,
-        "hotkey_ocr_translate" => register(app_handle, "hotkey_ocr_translate", ocr_translate, "")?,
+        "hotkey_ocr_recognize" => {
+            register(app_handle, "hotkey_ocr_recognize", ocr_recognize, "")?
+        }
+        "hotkey_ocr_translate" => {
+            register(app_handle, "hotkey_ocr_translate", ocr_translate, "")?
+        }
         "all" => {
-            register(
+            let mut errors = vec![];
+
+            if let Err(e) = register(
                 app_handle,
                 "hotkey_selection_translate",
                 selection_translate,
                 "",
-            )?;
-            register(app_handle, "hotkey_input_translate", input_translate, "")?;
-            register(app_handle, "hotkey_ocr_recognize", ocr_recognize, "")?;
-            register(app_handle, "hotkey_ocr_translate", ocr_translate, "")?;
+            ) {
+                errors.push(format!("hotkey_selection_translate: {}", e));
+            }
+            if let Err(e) = register(app_handle, "hotkey_input_translate", input_translate, "") {
+                errors.push(format!("hotkey_input_translate: {}", e));
+            }
+            if let Err(e) = register(app_handle, "hotkey_ocr_recognize", ocr_recognize, "") {
+                errors.push(format!("hotkey_ocr_recognize: {}", e));
+            }
+            if let Err(e) = register(app_handle, "hotkey_ocr_translate", ocr_translate, "") {
+                errors.push(format!("hotkey_ocr_translate: {}", e));
+            }
+
+            if !errors.is_empty() {
+                return Err(errors.join("\n"));
+            }
         }
         _ => {}
     }
@@ -92,7 +125,7 @@ pub fn register_shortcut_by_frontend(name: &str, shortcut: &str) -> Result<(), S
         "hotkey_ocr_translate" => {
             register(app_handle, "hotkey_ocr_translate", ocr_translate, shortcut)?
         }
-        _ => {}
+        _ => return Err(format!("Unknown hotkey name: {}", name)),
     }
     Ok(())
 }

--- a/src/window/Config/pages/Hotkey/index.jsx
+++ b/src/window/Config/pages/Hotkey/index.jsx
@@ -1,4 +1,3 @@
-import { unregister, isRegistered } from '@tauri-apps/api/globalShortcut';
 import toast, { Toaster } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { CardBody } from '@nextui-org/react';
@@ -46,10 +45,10 @@ const keyMap = {
 };
 
 export default function Hotkey() {
-    const [selectionTranslate, setSelectionTranslate] = useConfig('hotkey_selection_translate', '');
-    const [inputTranslate, setInputTranslate] = useConfig('hotkey_input_translate', '');
-    const [ocrRecognize, setOcrRecognize] = useConfig('hotkey_ocr_recognize', '');
-    const [ocrTranslate, setOcrTranslate] = useConfig('hotkey_ocr_translate', '');
+    const [selectionTranslate, setSelectionTranslate] = useConfig('hotkey_selection_translate', '', { sync: false });
+    const [inputTranslate, setInputTranslate] = useConfig('hotkey_input_translate', '', { sync: false });
+    const [ocrRecognize, setOcrRecognize] = useConfig('hotkey_ocr_recognize', '', { sync: false });
+    const [ocrTranslate, setOcrTranslate] = useConfig('hotkey_ocr_translate', '', { sync: false });
 
     const { t } = useTranslation();
     const toastStyle = useToastStyle();
@@ -93,24 +92,19 @@ export default function Hotkey() {
         }
     }
 
-    function registerHandler(name, key) {
-        isRegistered(key).then((res) => {
-            if (res) {
-                toast.error(t('config.hotkey.is_register'), { style: toastStyle });
-            } else {
-                invoke('register_shortcut_by_frontend', {
-                    name: name,
-                    shortcut: key,
-                }).then(
-                    () => {
-                        toast.success(t('config.hotkey.success'), { style: toastStyle });
-                    },
-                    (e) => {
-                        toast.error(e, { style: toastStyle });
-                    }
-                );
+    function registerHandler(name, key, setKey) {
+        invoke('register_shortcut_by_frontend', {
+            name: name,
+            shortcut: key,
+        }).then(
+            () => {
+                setKey(key, true);
+                toast.success(t('config.hotkey.success'), { style: toastStyle });
+            },
+            (e) => {
+                toast.error(e, { style: toastStyle });
             }
-        });
+        );
     }
 
     return (
@@ -129,17 +123,16 @@ export default function Hotkey() {
                             onKeyDown={(e) => {
                                 keyDown(e, setSelectionTranslate);
                             }}
-                            onFocus={() => {
-                                unregister(selectionTranslate);
-                                setSelectionTranslate('');
-                            }}
                             endContent={
                                 <Button
                                     size='sm'
                                     variant='flat'
-                                    className={`${selectionTranslate === '' && 'hidden'}`}
                                     onPress={() => {
-                                        registerHandler('hotkey_selection_translate', selectionTranslate);
+                                        registerHandler(
+                                            'hotkey_selection_translate',
+                                            selectionTranslate,
+                                            setSelectionTranslate
+                                        );
                                     }}
                                 >
                                     {t('common.ok')}
@@ -160,17 +153,12 @@ export default function Hotkey() {
                             onKeyDown={(e) => {
                                 keyDown(e, setInputTranslate);
                             }}
-                            onFocus={() => {
-                                unregister(inputTranslate);
-                                setInputTranslate('');
-                            }}
                             endContent={
                                 <Button
                                     size='sm'
                                     variant='flat'
-                                    className={`${inputTranslate === '' && 'hidden'}`}
                                     onPress={() => {
-                                        registerHandler('hotkey_input_translate', inputTranslate);
+                                        registerHandler('hotkey_input_translate', inputTranslate, setInputTranslate);
                                     }}
                                 >
                                     {t('common.ok')}
@@ -191,17 +179,12 @@ export default function Hotkey() {
                             onKeyDown={(e) => {
                                 keyDown(e, setOcrRecognize);
                             }}
-                            onFocus={() => {
-                                unregister(ocrRecognize);
-                                setOcrRecognize('');
-                            }}
                             endContent={
                                 <Button
                                     size='sm'
                                     variant='flat'
-                                    className={`${ocrRecognize === '' && 'hidden'}`}
                                     onPress={() => {
-                                        registerHandler('hotkey_ocr_recognize', ocrRecognize);
+                                        registerHandler('hotkey_ocr_recognize', ocrRecognize, setOcrRecognize);
                                     }}
                                 >
                                     {t('common.ok')}
@@ -222,17 +205,12 @@ export default function Hotkey() {
                             onKeyDown={(e) => {
                                 keyDown(e, setOcrTranslate);
                             }}
-                            onFocus={() => {
-                                unregister(ocrTranslate);
-                                setOcrTranslate('');
-                            }}
                             endContent={
                                 <Button
                                     size='sm'
                                     variant='flat'
-                                    className={`${ocrTranslate === '' && 'hidden'}`}
                                     onPress={() => {
-                                        registerHandler('hotkey_ocr_translate', ocrTranslate);
+                                        registerHandler('hotkey_ocr_translate', ocrTranslate, setOcrTranslate);
                                     }}
                                 >
                                     {t('common.ok')}


### PR DESCRIPTION
## Summary
- Make hotkey registration robust on backend:
  - unregister old shortcut before register
  - persist config only after successful backend flow
  - support clearing shortcut safely
  - avoid "all" registration being blocked by one failure (aggregate errors)
  - return error on unknown hotkey name
- Update Hotkey settings UI:
  - avoid persisting while typing (`sync: false`)
  - remove destructive onFocus unregister/clear behavior
  - persist only when backend registration succeeds

## Why
- Prevent invalid/failed hotkey values from being written to config
- Reduce frontend-backend coupling in unregister/register order
- Improve startup registration resilience


## 简要
- 增强后端热键注册的稳定性：
  - 注册新快捷键前先取消旧快捷键的注册
  - 仅在后端流程成功后才保存配置
  - 安全支持快捷键清除操作
  - 避免因单一注册失败导致“全部”注册被阻塞（聚合错误处理）
  - 对未知的热键名称返回错误提示
- 更新热键设置界面：
  - 输入时避免即时保存（设置 sync: false）
  - 移除聚焦时自动取消注册或清除的破坏性行为
  - 仅在后端注册成功后才保存配置

## 原因
- 防止无效或注册失败的热键值写入配置文件
- 降低前端与后端在取消注册/重新注册顺序上的耦合度
- 提升启动时热键注册的容错能力