### PR TITLE
Fix translate window shrinking on Windows with mixed DPI monitors

### DIFF
--- a/src-tauri/src/window.rs
+++ b/src-tauri/src/window.rs
@@ -154,13 +154,10 @@ fn translate_window() -> Window {
     };
 
     let monitor = window.current_monitor().unwrap().unwrap();
-    let dpi = monitor.scale_factor();
-
+    
+    // NOTE: translate_window_width/height are stored as logical size (see frontend resize listener).
     window
-        .set_size(tauri::PhysicalSize::new(
-            (width as f64) * dpi,
-            (height as f64) * dpi,
-        ))
+        .set_size(tauri::LogicalSize::new(width as f64, height as f64))
         .unwrap();
 
     let position_type = match get("translate_window_position") {


### PR DESCRIPTION
### What
Fix an issue where the translation window (selection translate) becomes smaller after each translation when "Remember window size" is enabled on Windows, especially with mixed-DPI multi-monitor setups (e.g. 150% + 100%).

### Why
`translate_window_width/height` are persisted from the frontend as **logical** sizes (converted from `outerSize()` via `toLogical(scaleFactor)`), but the Rust window creation code restored them as physical sizes by multiplying by `monitor.scale_factor()` again. This unit mismatch causes size drift across resizes/opens.

### How
Restore the translate window using logical units:
- Use `tauri::LogicalSize` for `set_size`
- Remove the extra `dpi` scaling on restore
- Add a note clarifying the stored units

