### PR TITLE
Add the NEU campus version of the Little Cow translation option and update the translation logic

### DIFF
--- a/src/i18n/locales/en_US.json
+++ b/src/i18n/locales/en_US.json
@@ -341,6 +341,7 @@
                 "niutrans": {
                     "title": "NiuTrans",
                     "https": "Use Https",
+                    "is_campus": "NEU Campus Network",
                     "apikey": "API Key"
                 },
                 "youdao": {

--- a/src/i18n/locales/zh_CN.json
+++ b/src/i18n/locales/zh_CN.json
@@ -341,6 +341,7 @@
                 "niutrans": {
                     "title": "小牛翻译",
                     "https": "使用 Https",
+                    "is_campus": "NEU校园版",
                     "apikey": "API Key"
                 },
                 "youdao": {

--- a/src/services/translate/niutrans/Config.jsx
+++ b/src/services/translate/niutrans/Config.jsx
@@ -18,6 +18,7 @@ export function Config(props) {
         {
             [INSTANCE_NAME_CONFIG_KEY]: t('services.translate.niutrans.title'),
             https: true,
+            is_campus: false,
             apikey: '',
         },
         { sync: false }
@@ -75,6 +76,19 @@ export function Config(props) {
                     >
                         {t('services.help')}
                     </Button>
+                </div>
+                <div className={'config-item'}>
+                    <Switch
+                        isSelected={config['is_campus'] ?? false}
+                        onValueChange={(v) => {
+                            setConfig({ ...config, is_campus: v });
+                        }}
+                        classNames={{
+                            base: 'flex flex-row-reverse justify-between w-full max-w-full',
+                        }}
+                    >
+                        NEU
+                    </Switch>
                 </div>
                 <div className={'config-item'}>
                     <Switch

--- a/src/services/translate/niutrans/Config.jsx
+++ b/src/services/translate/niutrans/Config.jsx
@@ -87,22 +87,24 @@ export function Config(props) {
                             base: 'flex flex-row-reverse justify-between w-full max-w-full',
                         }}
                     >
-                        NEU
+                        {t('services.translate.niutrans.is_campus')}
                     </Switch>
                 </div>
-                <div className={'config-item'}>
-                    <Switch
-                        isSelected={config['https'] ?? true}
-                        onValueChange={(v) => {
-                            setConfig({ ...config, https: v });
-                        }}
-                        classNames={{
-                            base: 'flex flex-row-reverse justify-between w-full max-w-full',
-                        }}
-                    >
-                        {t('services.translate.niutrans.https')}
-                    </Switch>
-                </div>
+                {!(config['is_campus'] ?? false) && (
+                    <div className={'config-item'}>
+                        <Switch
+                            isSelected={config['https'] ?? true}
+                            onValueChange={(v) => {
+                                setConfig({ ...config, https: v });
+                            }}
+                            classNames={{
+                                base: 'flex flex-row-reverse justify-between w-full max-w-full',
+                            }}
+                        >
+                            {t('services.translate.niutrans.https')}
+                        </Switch>
+                    </div>
+                )}
                 <div className={'config-item'}>
                     <Input
                         label={t('services.translate.niutrans.apikey')}

--- a/src/services/translate/niutrans/index.jsx
+++ b/src/services/translate/niutrans/index.jsx
@@ -3,9 +3,11 @@ import { fetch, Body } from '@tauri-apps/api/http';
 export async function translate(text, from, to, options = {}) {
     const { config } = options;
 
-    const { https, apikey } = config;
+    const { https, apikey, is_campus } = config;
 
-    const url = `${https ? 'https' : 'http'}://api.niutrans.com/NiuTransServer/translation`;
+    const url = is_campus 
+        ? `https://trans.neu.edu.cn/niutrans/textTranslation?apikey=${apikey}`
+        : `${https ? 'https' : 'http'}://api.niutrans.com/NiuTransServer/translation`;
 
     let res = await fetch(url, {
         method: 'POST',
@@ -15,7 +17,7 @@ export async function translate(text, from, to, options = {}) {
         body: Body.json({
             from: from,
             to: to,
-            apikey: apikey,
+            apikey: apikey, // 内部版如果不需要body里的apikey会自动忽略，公网版需要
             src_text: text,
         }),
     });
@@ -23,6 +25,15 @@ export async function translate(text, from, to, options = {}) {
     // 返回翻译结果
     if (res.ok) {
         let result = res.data;
+        if (is_campus) {
+            if (result.code === 200 && result.data && result.data.length > 0) {
+                return result.data.map(d => 
+                    d.sentences.map(s => s.data).join('')
+                ).join('\n').trim();
+            } else {
+                throw JSON.stringify(result);
+            }
+        }
         if (result && result['tgt_text']) {
             return result['tgt_text'].trim();
         } else {

--- a/src/services/translate/niutrans/index.jsx
+++ b/src/services/translate/niutrans/index.jsx
@@ -6,10 +6,10 @@ export async function translate(text, from, to, options = {}) {
     const { https, apikey, is_campus } = config;
 
     const url = is_campus 
-        ? `https://trans.neu.edu.cn/niutrans/textTranslation?apikey=${apikey}`
+        ? `https://trans.neu.edu.cn/niutrans/textTranslation`
         : `${https ? 'https' : 'http'}://api.niutrans.com/NiuTransServer/translation`;
 
-    let res = await fetch(url, {
+    let reqOptions = {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
@@ -20,7 +20,13 @@ export async function translate(text, from, to, options = {}) {
             apikey: apikey, // 内部版如果不需要body里的apikey会自动忽略，公网版需要
             src_text: text,
         }),
-    });
+    };
+
+    if (is_campus) {
+        reqOptions.query = { apikey: apikey };
+    }
+
+    let res = await fetch(url, reqOptions);
 
     // 返回翻译结果
     if (res.ok) {


### PR DESCRIPTION
增加了小牛翻译校园版接口，经测试可以使用。可提供apikey进行测试。
主要改动如下：

配置界面 (Config.jsx):
在小牛翻译的配置中增加了一个「NEU」校园版的开关选项。当开启此模式时，内部系统会自动拼接专属端点。

核心请求逻辑 (index.jsx):
判断到开启了 is_campus 后，将请求地址切换为 https://trans.neu.edu.cn/niutrans/textTranslation?apikey=${apikey}
处理请求体的格式：校园内部版将 apikey 直接放置在了URL Query，否则认证会有问题。

<img width="1965" height="871" alt="image" src="https://github.com/user-attachments/assets/c1b8c37c-a9c7-44aa-9ca3-7cea2e0e4095" />