### PR TITLE
fix: remove cmd.exe wrapper in run_binary to fix paths with spaces

### DIFF
--- a/src-tauri/src/cmd.rs
+++ b/src-tauri/src/cmd.rs
@@ -193,11 +193,9 @@ pub fn run_binary(
     let plugin_path = config_path.join(plugin_name);
 
     #[cfg(target_os = "windows")]
-    let mut cmd = Command::new("cmd");
+    let mut cmd = Command::new(&cmd_name);
     #[cfg(target_os = "windows")]
     let cmd = cmd.creation_flags(0x08000000);
-    #[cfg(target_os = "windows")]
-    let cmd = cmd.args(["/c", &cmd_name]);
     #[cfg(not(target_os = "windows"))]
     let mut cmd = Command::new(&cmd_name);
 


### PR DESCRIPTION
## Problem

When the Windows username contains spaces (e.g. `C:\Users\John Doe\`), plugins that call external binaries (Rapid OCR, Paddle OCR) fail with:
'C:\Users\John' is not recognized as an internal or external command, nor is it a runnable program or batch file.

## Root Cause

`run_binary` in `src-tauri/src/cmd.rs` wraps the executable call with `cmd.exe /c`:

```rust
let mut cmd = Command::new("cmd");
let cmd = cmd.creation_flags(0x08000000);
let cmd = cmd.args(["/c", &cmd_name]);
```

When both the executable path and arguments contain spaces, `cmd.exe /c` triggers a known quote-stripping bug: it strips the first and last quotes from the command string, causing paths to be truncated at the space.

## Fix

Remove the unnecessary cmd.exe wrapper and call the executable directly via `Command::new(&cmd_name)`, consistent with the pattern used elsewhere in the codebase (system_ocr.rs, window.rs). `The CREATE_NO_WINDOW` flag is already set via `creation_flags(0x08000000)`, making the cmd.exe wrapper redundant.

```rust
let mut cmd = Command::new(&cmd_name);
let cmd = cmd.creation_flags(0x08000000);
```

## Tested

- Built and verified on Windows 11 with username containing spaces
- Rapid OCR and Paddle OCR plugins now work correctly

Closes pot-app/pot-desktop#1279