### PR TITLE
fix(alibaba): use HTTPS for translation API endpoint

### DIFF
--- a/src/services/translate/alibaba/index.jsx
+++ b/src/services/translate/alibaba/index.jsx
@@ -17,7 +17,7 @@ export async function translate(text, from, to, options = {}) {
 
     let today = new Date();
     let timestamp = today.toISOString().replaceAll(/\.[0-9]*/g, '');
-    let endpoint = 'http://mt.cn-hangzhou.aliyuncs.com/';
+    let endpoint = 'https://mt.cn-hangzhou.aliyuncs.com/';
     let url_path = 'api/translate/web/general';
 
     let query = `AccessKeyId=${accesskey_id}&Action=TranslateGeneral&Format=JSON&FormatType=text&Scene=general&SignatureMethod=HMAC-SHA1&SignatureNonce=${getRandomNumber()}&SignatureVersion=1.0&SourceLanguage=${from}&SourceText=${encodeURIComponent(


### PR DESCRIPTION
## Summary

The Alibaba translation service in `src/services/translate/alibaba/index.jsx` sends API requests over plaintext HTTP (`http://mt.cn-hangzhou.aliyuncs.com/`). This exposes the user's `AccessKeyId`, HMAC signature, and translated text content to any network-level observer (e.g., someone on the same WiFi network, a compromised router, or an ISP-level monitor).

This is a one-character fix: `http://` to `https://`.

## Vulnerability Details

**CWE-319: Cleartext Transmission of Sensitive Information**

In `src/services/translate/alibaba/index.jsx` at line 20, the endpoint URL uses the `http` scheme:

```js
let endpoint = 'http://mt.cn-hangzhou.aliyuncs.com/';
```

The `AccessKeyId` and HMAC `Signature` are appended as query parameters to this URL (lines 23-41), and the full URL is passed to `fetch()` at line 43. Because the request uses plaintext HTTP, all of this data — credentials, signature, and the user's source text — travels unencrypted over the network.

Every other cloud translation provider in the codebase already uses HTTPS:
- Baidu: `https://fanyi-api.baidu.com/api/trans/vip/translate`
- Tencent: `https://` + endpoint
- Volcengine: uses HTTPS

Alibaba was the sole outlier.

## Proof of Concept

An attacker on the same network as a pot-desktop user can capture the Alibaba API credentials passively:

```bash
# On the attacker machine (same LAN as the victim), capture HTTP traffic
# to the Alibaba translation endpoint:
tcpdump -i any -A 'host mt.cn-hangzhou.aliyuncs.com and port 80' | \
  grep -oP 'AccessKeyId=[^&]+'
```

When the victim triggers an Alibaba translation in pot-desktop, the GET request is sent in cleartext. The attacker's packet capture will show:

```
GET /api/translate/web/general?AccessKeyId=LTAI5t...&Action=TranslateGeneral&...&Signature=...&SourceText=hello%20world HTTP/1.1
Host: mt.cn-hangzhou.aliyuncs.com
```

This reveals:
1. The user's `AccessKeyId`
2. The computed HMAC `Signature` (replayable within its nonce window)
3. The full `SourceText` being translated

The Alibaba server at `mt.cn-hangzhou.aliyuncs.com` accepts both HTTP and HTTPS without redirecting HTTP to HTTPS, so the fix must be applied client-side — the server will not protect the user automatically.

## Fix Description

Changed the endpoint scheme from `http://` to `https://` in `src/services/translate/alibaba/index.jsx`:

```diff
-    let endpoint = 'http://mt.cn-hangzhou.aliyuncs.com/';
+    let endpoint = 'https://mt.cn-hangzhou.aliyuncs.com/';
```

This is safe because:
- The HMAC signature is computed over the **path** (`/`) and **query parameters**, not the URL scheme. The `stringToSign` at line 30 starts with `'GET' + '&' + encodeURIComponent('/')`, so switching to HTTPS does not invalidate the signature.
- The Alibaba Machine Translation API endpoint supports TLS — `https://mt.cn-hangzhou.aliyuncs.com` responds correctly with a valid certificate.

## Testing

- Verified that the HMAC signature computation (`stringToSign` on line 30) uses `encodeURIComponent('/')` as the canonicalized resource, not the full URL with scheme, so the signature is identical regardless of HTTP vs HTTPS.
- Confirmed `https://mt.cn-hangzhou.aliyuncs.com` serves valid TLS (the certificate chain is issued for `*.cn-hangzhou.aliyuncs.com`).
- Confirmed the diff is minimal: 1 file changed, 1 line modified (scheme change only).

## Adversarial Review

Before submitting, we attempted to disprove this finding. We considered whether the Alibaba server might automatically redirect HTTP to HTTPS (it does not — it serves responses on port 80 without a 3xx redirect). We also checked whether Tauri's `fetch` implementation might enforce HTTPS or pin certificates (it does not — it follows the scheme in the URL as-is). The plaintext transmission is real and exploitable under the stated preconditions (network-level attacker + user has configured Alibaba translation).

---

<sub>_Submitted by Sebastion — autonomous open-source security research from [Foundation Machines](https://foundationmachines.ai). Free for public repos via the [Sebastion AI GitHub App](https://github.com/apps/sebastionai)._</sub>