### PR TITLE
feat: support Windows mouse side-button hotkeys

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -46,7 +46,7 @@ macos-accessibility-client = "0.0.1"
 window-shadows = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-windows = {version="0.58.0",features= ["Win32_UI_WindowsAndMessaging", "Win32_Foundation", "Graphics_Imaging", "Media_Ocr", "Foundation", "Globalization", "Storage", "Storage_Streams"] }
+windows = {version="0.58.0",features= ["Win32_UI_WindowsAndMessaging", "Win32_System_Threading", "Win32_Foundation", "Graphics_Imaging", "Media_Ocr", "Foundation", "Globalization", "Storage", "Storage_Streams"] }
 window-shadows = "0.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/src-tauri/src/hotkey.rs
+++ b/src-tauri/src/hotkey.rs
@@ -1,4 +1,5 @@
 use crate::config::{get, set};
+use crate::mouse_hotkey;
 use crate::window::{input_translate, ocr_recognize, ocr_translate, selection_translate};
 use crate::APP;
 use log::{info, warn};
@@ -23,6 +24,9 @@ where
     };
 
     if !hotkey.is_empty() {
+        if mouse_hotkey::is_mouse_shortcut(&hotkey) {
+            return mouse_hotkey::register(name, &hotkey);
+        }
         match app_handle
             .global_shortcut_manager()
             .register(hotkey.as_str(), handler)
@@ -92,7 +96,38 @@ pub fn register_shortcut_by_frontend(name: &str, shortcut: &str) -> Result<(), S
         "hotkey_ocr_translate" => {
             register(app_handle, "hotkey_ocr_translate", ocr_translate, shortcut)?
         }
-        _ => {}
+        _ => return Err("Unknown hotkey action".to_string()),
     }
     Ok(())
+}
+
+#[tauri::command]
+pub fn is_shortcut_registered(shortcut: &str) -> Result<bool, String> {
+    if shortcut.is_empty() {
+        return Ok(false);
+    }
+    if mouse_hotkey::is_mouse_shortcut(shortcut) {
+        return Ok(mouse_hotkey::is_registered(shortcut));
+    }
+    APP.get()
+        .unwrap()
+        .global_shortcut_manager()
+        .is_registered(shortcut)
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+pub fn unregister_shortcut(shortcut: &str) -> Result<(), String> {
+    if shortcut.is_empty() {
+        return Ok(());
+    }
+    if mouse_hotkey::is_mouse_shortcut(shortcut) {
+        mouse_hotkey::unregister(shortcut);
+        return Ok(());
+    }
+    APP.get()
+        .unwrap()
+        .global_shortcut_manager()
+        .unregister(shortcut)
+        .map_err(|error| error.to_string())
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -8,6 +8,7 @@ mod config;
 mod error;
 mod hotkey;
 mod lang_detect;
+mod mouse_hotkey;
 mod screenshot;
 mod server;
 mod system_ocr;
@@ -139,6 +140,8 @@ fn main() {
             run_binary,
             open_devtools,
             register_shortcut_by_frontend,
+            is_shortcut_registered,
+            unregister_shortcut,
             update_tray,
             updater_window,
             screenshot,
@@ -153,9 +156,9 @@ fn main() {
         .build(tauri::generate_context!())
         .expect("error while running tauri application")
         // 窗口关闭不退出
-        .run(|_app_handle, event| {
-            if let tauri::RunEvent::ExitRequested { api, .. } = event {
-                api.prevent_exit();
-            }
+        .run(|_app_handle, event| match event {
+            tauri::RunEvent::ExitRequested { api, .. } => api.prevent_exit(),
+            tauri::RunEvent::Exit => mouse_hotkey::shutdown(),
+            _ => {}
         });
 }

--- a/src-tauri/src/mouse_hotkey.rs
+++ b/src-tauri/src/mouse_hotkey.rs
@@ -1,0 +1,169 @@
+#[cfg(target_os = "windows")]
+mod platform {
+    use crate::window::{input_translate, ocr_recognize, ocr_translate, selection_translate};
+    use log::{info, warn};
+    use once_cell::sync::Lazy;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+    use std::thread;
+    use windows::Win32::Foundation::{HINSTANCE, LPARAM, LRESULT, WPARAM};
+    use windows::Win32::UI::WindowsAndMessaging::{
+        CallNextHookEx, GetMessageW, PostThreadMessageW, SetWindowsHookExW, HHOOK, MSG,
+        MSLLHOOKSTRUCT, WH_MOUSE_LL, WM_QUIT, WM_XBUTTONDBLCLK, WM_XBUTTONDOWN, WM_XBUTTONUP,
+        XBUTTON1, XBUTTON2,
+    };
+
+    static BINDINGS: Lazy<Mutex<HashMap<String, String>>> =
+        Lazy::new(|| Mutex::new(HashMap::new()));
+    static LISTENER_STARTED: Lazy<Mutex<bool>> = Lazy::new(|| Mutex::new(false));
+    static LISTENER_THREAD_ID: Lazy<Mutex<Option<u32>>> = Lazy::new(|| Mutex::new(None));
+
+    fn mouse_button(mouse_data: u32) -> Option<&'static str> {
+        match (mouse_data >> 16) as u16 {
+            XBUTTON1 => Some("Mouse4"),
+            XBUTTON2 => Some("Mouse5"),
+            _ => None,
+        }
+    }
+
+    fn trigger(name: String) {
+        thread::spawn(move || match name.as_str() {
+            "hotkey_selection_translate" => selection_translate(),
+            "hotkey_input_translate" => input_translate(),
+            "hotkey_ocr_recognize" => ocr_recognize(),
+            "hotkey_ocr_translate" => ocr_translate(),
+            _ => {}
+        });
+    }
+
+    unsafe extern "system" fn mouse_hook(code: i32, w_param: WPARAM, l_param: LPARAM) -> LRESULT {
+        if code >= 0 {
+            let message = w_param.0 as u32;
+            if matches!(message, WM_XBUTTONDOWN | WM_XBUTTONUP | WM_XBUTTONDBLCLK) {
+                let hook_data = &*(l_param.0 as *const MSLLHOOKSTRUCT);
+                if let Some(shortcut) = mouse_button(hook_data.mouseData) {
+                    let binding = BINDINGS.lock().unwrap().get(shortcut).cloned();
+                    if binding.is_some() {
+                        if matches!(message, WM_XBUTTONDOWN | WM_XBUTTONDBLCLK) {
+                            trigger(binding.unwrap());
+                        }
+                        return LRESULT(1);
+                    }
+                }
+            }
+        }
+        CallNextHookEx(HHOOK::default(), code, w_param, l_param)
+    }
+
+    fn ensure_listener() -> Result<(), String> {
+        let mut started = LISTENER_STARTED.lock().unwrap();
+        if *started {
+            return Ok(());
+        }
+
+        let (sender, receiver) = std::sync::mpsc::channel();
+        thread::spawn(move || unsafe {
+            *LISTENER_THREAD_ID.lock().unwrap() =
+                Some(windows::Win32::System::Threading::GetCurrentThreadId());
+            match SetWindowsHookExW(WH_MOUSE_LL, Some(mouse_hook), HINSTANCE::default(), 0) {
+                Ok(hook) => {
+                    let _ = sender.send(Ok(()));
+                    info!("Started global mouse hotkey listener");
+                    let mut message = MSG::default();
+                    while GetMessageW(&mut message, None, 0, 0).as_bool() {}
+                    if let Err(error) =
+                        windows::Win32::UI::WindowsAndMessaging::UnhookWindowsHookEx(hook)
+                    {
+                        warn!(
+                            "Failed to release global mouse hotkey listener: {:?}",
+                            error
+                        );
+                    }
+                }
+                Err(error) => {
+                    *LISTENER_THREAD_ID.lock().unwrap() = None;
+                    let _ = sender.send(Err(error.to_string()));
+                }
+            }
+        });
+
+        receiver.recv().map_err(|error| error.to_string())??;
+        *started = true;
+        Ok(())
+    }
+
+    pub fn register(name: &str, shortcut: &str) -> Result<(), String> {
+        if is_registered(shortcut) {
+            return Err("The hotkey is already registered".to_string());
+        }
+        ensure_listener()?;
+        BINDINGS
+            .lock()
+            .unwrap()
+            .insert(shortcut.to_string(), name.to_string());
+        info!(
+            "Registered global mouse shortcut: {} for {}",
+            shortcut, name
+        );
+        Ok(())
+    }
+
+    pub fn unregister(shortcut: &str) {
+        BINDINGS.lock().unwrap().remove(shortcut);
+    }
+
+    pub fn is_registered(shortcut: &str) -> bool {
+        BINDINGS.lock().unwrap().contains_key(shortcut)
+    }
+
+    pub fn shutdown() {
+        if let Some(thread_id) = *LISTENER_THREAD_ID.lock().unwrap() {
+            unsafe {
+                let _ =
+                    PostThreadMessageW(thread_id, WM_QUIT, WPARAM::default(), LPARAM::default());
+            }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn installs_listener_and_manages_mouse_binding() {
+            assert_eq!(mouse_button((XBUTTON1 as u32) << 16), Some("Mouse4"));
+            assert_eq!(mouse_button((XBUTTON2 as u32) << 16), Some("Mouse5"));
+
+            register("hotkey_selection_translate", "Mouse4").unwrap();
+            assert!(is_registered("Mouse4"));
+            assert!(register("hotkey_input_translate", "Mouse4").is_err());
+
+            unregister("Mouse4");
+            assert!(!is_registered("Mouse4"));
+            shutdown();
+        }
+    }
+}
+
+pub fn is_mouse_shortcut(shortcut: &str) -> bool {
+    matches!(shortcut, "Mouse4" | "Mouse5")
+}
+
+#[cfg(target_os = "windows")]
+pub use platform::{is_registered, register, shutdown, unregister};
+
+#[cfg(not(target_os = "windows"))]
+pub fn register(_name: &str, _shortcut: &str) -> Result<(), String> {
+    Err("Mouse shortcuts are only supported on Windows".to_string())
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn unregister(_shortcut: &str) {}
+
+#[cfg(not(target_os = "windows"))]
+pub fn is_registered(_shortcut: &str) -> bool {
+    false
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn shutdown() {}

--- a/src/window/Config/pages/Hotkey/index.jsx
+++ b/src/window/Config/pages/Hotkey/index.jsx
@@ -1,16 +1,12 @@
-import { unregister, isRegistered } from '@tauri-apps/api/globalShortcut';
 import toast, { Toaster } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
-import { CardBody } from '@nextui-org/react';
-import { Button } from '@nextui-org/react';
-import { Input } from '@nextui-org/react';
-import { Card } from '@nextui-org/react';
-import React from 'react';
+import { Button, Card, CardBody, Input } from '@nextui-org/react';
+import { invoke } from '@tauri-apps/api';
+import React, { useRef } from 'react';
 
 import { useConfig } from '../../../../hooks/useConfig';
 import { useToastStyle } from '../../../../hooks';
 import { osType } from '../../../../utils/env';
-import { invoke } from '@tauri-apps/api';
 
 const keyMap = {
     Backquote: '`',
@@ -45,202 +41,186 @@ const keyMap = {
     Suspend: 'Suspend',
 };
 
-export default function Hotkey() {
-    const [selectionTranslate, setSelectionTranslate] = useConfig('hotkey_selection_translate', '');
-    const [inputTranslate, setInputTranslate] = useConfig('hotkey_input_translate', '');
-    const [ocrRecognize, setOcrRecognize] = useConfig('hotkey_ocr_recognize', '');
-    const [ocrTranslate, setOcrTranslate] = useConfig('hotkey_ocr_translate', '');
+function keyboardShortcut(e) {
+    if (e.keyCode === 8) {
+        return '';
+    }
 
+    const keys = [];
+    e.ctrlKey && keys.push('Ctrl');
+    e.shiftKey && keys.push('Shift');
+    e.metaKey && keys.push(osType === 'Darwin' ? 'Command' : 'Super');
+    e.altKey && keys.push('Alt');
+
+    let code = e.code;
+    if (code.startsWith('Key')) {
+        code = code.substring(3);
+    } else if (code.startsWith('Digit')) {
+        code = code.substring(5);
+    } else if (code.startsWith('Numpad')) {
+        code = 'Num' + code.substring(6);
+    } else if (code.startsWith('Arrow')) {
+        code = code.substring(5);
+    } else if (code.startsWith('Intl')) {
+        code = code.substring(4);
+    } else if (/F\d+/.test(code)) {
+        // Keep function-key names unchanged.
+    } else {
+        code = keyMap[code] ?? '';
+    }
+
+    code && keys.push(code);
+    return keys.join('+');
+}
+
+function HotkeyInput({ name, label, value, setValue }) {
     const { t } = useTranslation();
     const toastStyle = useToastStyle();
+    const previousValue = useRef('');
+    const editing = useRef(false);
+    const unregisterPromise = useRef(Promise.resolve());
 
-    function keyDown(e, setKey) {
-        e.preventDefault();
-        if (e.keyCode === 8) {
-            setKey('');
-        } else {
-            let newValue = '';
-            if (e.ctrlKey) {
-                newValue = 'Ctrl';
+    async function restorePrevious() {
+        await unregisterPromise.current;
+        if (previousValue.current) {
+            try {
+                await invoke('register_shortcut_by_frontend', {
+                    name,
+                    shortcut: previousValue.current,
+                });
+            } catch (error) {
+                toast.error(String(error), { style: toastStyle });
             }
-            if (e.shiftKey) {
-                newValue = `${newValue}${newValue.length > 0 ? '+' : ''}Shift`;
+        }
+        setValue(previousValue.current);
+        editing.current = false;
+    }
+
+    function beginEditing() {
+        if (editing.current) {
+            return;
+        }
+        editing.current = true;
+        previousValue.current = value;
+        unregisterPromise.current = invoke('unregister_shortcut', { shortcut: value }).catch((error) => {
+            toast.error(String(error), { style: toastStyle });
+        });
+        setValue('');
+    }
+
+    async function registerShortcut() {
+        try {
+            await unregisterPromise.current;
+            if (await invoke('is_shortcut_registered', { shortcut: value })) {
+                toast.error(t('config.hotkey.is_register'), { style: toastStyle });
+                await restorePrevious();
+                return;
             }
-            if (e.metaKey) {
-                newValue = `${newValue}${newValue.length > 0 ? '+' : ''}${osType === 'Darwin' ? 'Command' : 'Super'}`;
-            }
-            if (e.altKey) {
-                newValue = `${newValue}${newValue.length > 0 ? '+' : ''}Alt`;
-            }
-            let code = e.code;
-            if (code.startsWith('Key')) {
-                code = code.substring(3);
-            } else if (code.startsWith('Digit')) {
-                code = code.substring(5);
-            } else if (code.startsWith('Numpad')) {
-                code = 'Num' + code.substring(6);
-            } else if (code.startsWith('Arrow')) {
-                code = code.substring(5);
-            } else if (code.startsWith('Intl')) {
-                code = code.substring(4);
-            } else if (/F\d+/.test(code)) {
-            } else if (keyMap[code] !== undefined) {
-                code = keyMap[code];
-            } else {
-                code = '';
-            }
-            setKey(`${newValue}${newValue.length > 0 && code.length > 0 ? '+' : ''}${code}`);
+            await invoke('register_shortcut_by_frontend', { name, shortcut: value });
+            setValue(value, true);
+            previousValue.current = value;
+            editing.current = false;
+            toast.success(t('config.hotkey.success'), { style: toastStyle });
+        } catch (error) {
+            toast.error(String(error), { style: toastStyle });
+            await restorePrevious();
         }
     }
 
-    function registerHandler(name, key) {
-        isRegistered(key).then((res) => {
-            if (res) {
-                toast.error(t('config.hotkey.is_register'), { style: toastStyle });
-            } else {
-                invoke('register_shortcut_by_frontend', {
-                    name: name,
-                    shortcut: key,
-                }).then(
-                    () => {
-                        toast.success(t('config.hotkey.success'), { style: toastStyle });
-                    },
-                    (e) => {
-                        toast.error(e, { style: toastStyle });
+    return (
+        <div className='config-item'>
+            <h3 className='my-auto'>{label}</h3>
+            {value !== null && (
+                <Input
+                    type='hotkey'
+                    variant='bordered'
+                    value={value}
+                    label={t('config.hotkey.set_hotkey')}
+                    className='max-w-[50%]'
+                    onKeyDown={(e) => {
+                        e.preventDefault();
+                        setValue(keyboardShortcut(e));
+                    }}
+                    onMouseDown={(e) => {
+                        if (osType !== 'Windows_NT' || ![3, 4].includes(e.button)) {
+                            return;
+                        }
+                        e.preventDefault();
+                        e.stopPropagation();
+                        beginEditing();
+                        setValue(e.button === 3 ? 'Mouse4' : 'Mouse5');
+                    }}
+                    onMouseUp={(e) => {
+                        if ([3, 4].includes(e.button)) {
+                            e.preventDefault();
+                            e.stopPropagation();
+                        }
+                    }}
+                    onAuxClick={(e) => {
+                        if ([3, 4].includes(e.button)) {
+                            e.preventDefault();
+                            e.stopPropagation();
+                        }
+                    }}
+                    onFocus={beginEditing}
+                    onBlur={() => {
+                        if (editing.current) {
+                            restorePrevious().catch((error) => {
+                                toast.error(String(error), { style: toastStyle });
+                            });
+                        }
+                    }}
+                    endContent={
+                        <Button
+                            size='sm'
+                            variant='flat'
+                            onMouseDown={(e) => e.preventDefault()}
+                            onPress={registerShortcut}
+                        >
+                            {t('common.ok')}
+                        </Button>
                     }
-                );
-            }
-        });
-    }
+                />
+            )}
+        </div>
+    );
+}
+
+export default function Hotkey() {
+    const [selectionTranslate, setSelectionTranslate] = useConfig('hotkey_selection_translate', '', { sync: false });
+    const [inputTranslate, setInputTranslate] = useConfig('hotkey_input_translate', '', { sync: false });
+    const [ocrRecognize, setOcrRecognize] = useConfig('hotkey_ocr_recognize', '', { sync: false });
+    const [ocrTranslate, setOcrTranslate] = useConfig('hotkey_ocr_translate', '', { sync: false });
+    const { t } = useTranslation();
 
     return (
         <Card>
             <Toaster />
             <CardBody>
-                <div className='config-item'>
-                    <h3 className='my-auto'>{t('config.hotkey.selection_translate')}</h3>
-                    {selectionTranslate !== null && (
-                        <Input
-                            type='hotkey'
-                            variant='bordered'
-                            value={selectionTranslate}
-                            label={t('config.hotkey.set_hotkey')}
-                            className='max-w-[50%]'
-                            onKeyDown={(e) => {
-                                keyDown(e, setSelectionTranslate);
-                            }}
-                            onFocus={() => {
-                                unregister(selectionTranslate);
-                                setSelectionTranslate('');
-                            }}
-                            endContent={
-                                <Button
-                                    size='sm'
-                                    variant='flat'
-                                    className={`${selectionTranslate === '' && 'hidden'}`}
-                                    onPress={() => {
-                                        registerHandler('hotkey_selection_translate', selectionTranslate);
-                                    }}
-                                >
-                                    {t('common.ok')}
-                                </Button>
-                            }
-                        />
-                    )}
-                </div>
-                <div className='config-item'>
-                    <h3 className='my-auto'>{t('config.hotkey.input_translate')}</h3>
-                    {inputTranslate !== null && (
-                        <Input
-                            type='hotkey'
-                            variant='bordered'
-                            value={inputTranslate}
-                            label={t('config.hotkey.set_hotkey')}
-                            className='max-w-[50%]'
-                            onKeyDown={(e) => {
-                                keyDown(e, setInputTranslate);
-                            }}
-                            onFocus={() => {
-                                unregister(inputTranslate);
-                                setInputTranslate('');
-                            }}
-                            endContent={
-                                <Button
-                                    size='sm'
-                                    variant='flat'
-                                    className={`${inputTranslate === '' && 'hidden'}`}
-                                    onPress={() => {
-                                        registerHandler('hotkey_input_translate', inputTranslate);
-                                    }}
-                                >
-                                    {t('common.ok')}
-                                </Button>
-                            }
-                        />
-                    )}
-                </div>
-                <div className='config-item'>
-                    <h3 className='my-auto'>{t('config.hotkey.ocr_recognize')}</h3>
-                    {ocrRecognize !== null && (
-                        <Input
-                            type='hotkey'
-                            variant='bordered'
-                            value={ocrRecognize}
-                            label={t('config.hotkey.set_hotkey')}
-                            className='max-w-[50%]'
-                            onKeyDown={(e) => {
-                                keyDown(e, setOcrRecognize);
-                            }}
-                            onFocus={() => {
-                                unregister(ocrRecognize);
-                                setOcrRecognize('');
-                            }}
-                            endContent={
-                                <Button
-                                    size='sm'
-                                    variant='flat'
-                                    className={`${ocrRecognize === '' && 'hidden'}`}
-                                    onPress={() => {
-                                        registerHandler('hotkey_ocr_recognize', ocrRecognize);
-                                    }}
-                                >
-                                    {t('common.ok')}
-                                </Button>
-                            }
-                        />
-                    )}
-                </div>
-                <div className='config-item'>
-                    <h3 className='my-auto'>{t('config.hotkey.ocr_translate')}</h3>
-                    {ocrTranslate !== null && (
-                        <Input
-                            type='hotkey'
-                            variant='bordered'
-                            value={ocrTranslate}
-                            label={t('config.hotkey.set_hotkey')}
-                            className='max-w-[50%]'
-                            onKeyDown={(e) => {
-                                keyDown(e, setOcrTranslate);
-                            }}
-                            onFocus={() => {
-                                unregister(ocrTranslate);
-                                setOcrTranslate('');
-                            }}
-                            endContent={
-                                <Button
-                                    size='sm'
-                                    variant='flat'
-                                    className={`${ocrTranslate === '' && 'hidden'}`}
-                                    onPress={() => {
-                                        registerHandler('hotkey_ocr_translate', ocrTranslate);
-                                    }}
-                                >
-                                    {t('common.ok')}
-                                </Button>
-                            }
-                        />
-                    )}
-                </div>
+                <HotkeyInput
+                    name='hotkey_selection_translate'
+                    label={t('config.hotkey.selection_translate')}
+                    value={selectionTranslate}
+                    setValue={setSelectionTranslate}
+                />
+                <HotkeyInput
+                    name='hotkey_input_translate'
+                    label={t('config.hotkey.input_translate')}
+                    value={inputTranslate}
+                    setValue={setInputTranslate}
+                />
+                <HotkeyInput
+                    name='hotkey_ocr_recognize'
+                    label={t('config.hotkey.ocr_recognize')}
+                    value={ocrRecognize}
+                    setValue={setOcrRecognize}
+                />
+                <HotkeyInput
+                    name='hotkey_ocr_translate'
+                    label={t('config.hotkey.ocr_translate')}
+                    value={ocrTranslate}
+                    setValue={setOcrTranslate}
+                />
             </CardBody>
         </Card>
     );


### PR DESCRIPTION
## Summary
- add Windows global Mouse4/Mouse5 hotkey listener
- unify keyboard and mouse shortcut registration APIs
- make hotkey settings transactional and capture mouse side buttons

## Verification
- cargo check
- cargo test installs_listener_and_manages_mouse_binding
- vite production build
- Tauri NSIS build
- installed and launched the generated Windows package